### PR TITLE
Set up Cursor Cloud dev environment (AGENTS.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,22 @@
+# AGENTS.md
+
+## Cursor Cloud specific instructions
+
+CicloMapa is a single-page frontend web app (Create React App + CRACO, React 19, TypeScript, yarn). There is **no backend server in this repo** — all "backends" are third-party HTTP APIs called directly from the browser (Firebase config is hardcoded in `src/Storage.js`; Overpass/Nominatim/Valhalla are public and keyless).
+
+### Running / services
+
+- Dev server: `yarn start` (CRACO, serves on port 3000). Use `BROWSER=none yarn start` in headless environments so it does not try to open a browser.
+- Standard scripts live in `package.json`: `yarn lint`, `yarn typecheck`, `yarn format:check`, `yarn test --watchAll=false`, `yarn build`, `yarn e2e`, `yarn e2e:apis`.
+- CI reference: `.github/workflows/ci.yml` (Node 22, `yarn install --frozen-lockfile`, then format:check → lint → typecheck → unit tests → `yarn playwright install --with-deps chromium` → `yarn e2e:apis`).
+
+### Required environment variable (non-obvious, hard blocker)
+
+- **`REACT_APP_MAPBOX_ACCESS_TOKEN` is required for the app to render at all.** `src/features/map/mapboxGeocoding.js` constructs a Mapbox client at module-load time, so with no token the whole app throws `Cannot create a client without an access token` and shows a black error screen — this happens even with `?e2e=1`. Set this env var (e.g. a `.env` file at repo root or a Cloud secret) before doing any browser-based work or running the browser e2e smoke tests.
+- Optional keys degrade gracefully when absent: `REACT_APP_OPENROUTESERVICE_API_KEY`, `REACT_APP_GRAPHHOPPER_API_KEY`, `REACT_APP_GOOGLE_PLACES_API_KEY`, `REACT_APP_AIRTABLE_API_KEY` / `REACT_APP_AIRTABLE_BASE_ID`, `REACT_APP_PMTILES_URL` / `REACT_APP_PMTILES_FILENAME`.
+
+### Testing notes
+
+- `yarn e2e:apis` uses Playwright's HTTP `request` context only (no browser, no dev server needed) and checks public OSM/routing endpoints; provider tests that need keys skip when the key is unset. This is the e2e suite CI runs.
+- `yarn e2e` (browser smoke, `e2e/smoke.spec.ts`) navigates with `?e2e=1` to skip Mapbox GL map init, but still requires `REACT_APP_MAPBOX_ACCESS_TOKEN` to be set (module-load reason above) and a running dev server. It needs browsers: `yarn playwright install chromium` first. It is not run in CI.
+- `yarn lint` currently emits many `react/prop-types` warnings but exits 0 (warnings only, no errors).


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## Summary

Sets up the development environment for CicloMapa in Cursor Cloud and documents non-obvious startup caveats for future agents.

- Adds `AGENTS.md` with a `## Cursor Cloud specific instructions` section describing services, standard commands (referencing `package.json` / CI), and the key gotcha that `REACT_APP_MAPBOX_ACCESS_TOKEN` is required for the app to render at all (module-load crash otherwise).
- Update script (configured separately via the environment tool): `yarn install --frozen-lockfile`.

No application code changed.

## Verification (all run in the cloud VM)

- `yarn install --frozen-lockfile` — succeeds (Node 22, yarn 1.22)
- `yarn lint` — 0 errors (react/prop-types warnings only)
- `yarn typecheck` — passes
- `yarn format:check` — passes
- `yarn test --watchAll=false` — 27 suites, 158 passed, 1 skipped
- `yarn start` — compiles, serves HTTP 200 on :3000
- `yarn e2e:apis` — 3 public API tests pass (Overpass, Nominatim, Valhalla); keyed provider tests skip when unset

## Known blocker

The interactive map hello-world (viewing a city's cycling map) requires a valid `REACT_APP_MAPBOX_ACCESS_TOKEN`. Without it the app throws `Cannot create a client without an access token` at module load and renders a black error screen.

[App error screen without Mapbox token](https://cursor.com/agents/bc-ff5b8277-b089-4a0c-8dbb-44c85ab72945/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fapp_missing_mapbox_token_error.webp)

<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-ff5b8277-b089-4a0c-8dbb-44c85ab72945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-ff5b8277-b089-4a0c-8dbb-44c85ab72945"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

