### PR TITLE
Product UX: routes, city picker, PWA, glass, geolocation

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -23,6 +23,7 @@ import {
 } from './config/citySlugCatalog.js';
 import { isPrivacyPolicyLocation, PRIVACY_POLICY_PATH } from './config/routes.js';
 import { flyMapToCityFocus } from './Map.js';
+import { flyMapTo, flyMapToCinematic } from './features/map/mapCamera.js';
 import { isAreaBrowsePlaceResult } from './GooglePlacesGeocoder.js';
 import { DirectionsProvider } from './contexts/DirectionsContext';
 import {
@@ -882,12 +883,11 @@ class App extends Component {
         const flyOptions = {
           center: target.center,
           duration: 3000,
-          essential: true,
         };
         if (target.zoom !== null) {
           flyOptions.zoom = target.zoom;
         }
-        map.flyTo(flyOptions);
+        flyMapToCinematic(map, flyOptions);
       } catch (e) {
         console.error('Failed to apply pending flyto:', e);
       }
@@ -1879,10 +1879,9 @@ class App extends Component {
         this.deferOrApplyCityFocus({ lat, lng, placeName });
         return;
       }
-      this.state.map.flyTo({
+      flyMapTo(this.state.map, {
         center: [lng, lat],
         zoom,
-        duration: 1500,
       });
     });
   };

--- a/src/App.js
+++ b/src/App.js
@@ -81,6 +81,8 @@ class App extends Component {
   _lastExplicitCityNavTimestamp = 0;
   _welcomeMapBootScheduled = false;
   _unmounted = false;
+  /** Mobile directions panel open state (kept off React state to avoid App-wide re-renders). */
+  _isDirectionsPanelOpen = false;
 
   getStorage() {
     if (!this._storage) {
@@ -275,7 +277,6 @@ class App extends Component {
       mapKey: 0,
       fromPoint: fromPoint,
       toPoint: toPoint,
-      isDirectionsPanelOpen: false,
       airtableMetadataRecords: null,
       airtableCityFields: null,
       globalSearchPin: null,
@@ -1796,7 +1797,7 @@ class App extends Component {
   }
 
   onDirectionsPanelToggle(isOpen) {
-    this.setState({ isDirectionsPanelOpen: isOpen });
+    this._isDirectionsPanelOpen = isOpen;
   }
 
   setFromPoint = (point) => {

--- a/src/App.js
+++ b/src/App.js
@@ -4,6 +4,7 @@ import debounce from 'lodash.debounce';
 
 import { appNotification } from './antdNotification';
 import AntdAppShell from './components/AntdAppShell.jsx';
+import PwaUpdateBanner from './PwaUpdateBanner.jsx';
 
 import { MdRemove as IconRemove, MdAdd as IconAdd } from 'react-icons/md';
 
@@ -1932,6 +1933,7 @@ class App extends Component {
     };
     return (
       <AntdAppShell isDarkMode={this.state.isDarkMode}>
+        <PwaUpdateBanner isDarkMode={this.state.isDarkMode} />
         <DirectionsProvider>
           <AppLayout
             state={this.state}

--- a/src/App.js
+++ b/src/App.js
@@ -1667,7 +1667,7 @@ class App extends Component {
     // depends on. Geolocation only warms up if permission was already granted,
     // so we don't pop a surprise prompt before the user asks for it.
     userLocationCache.warmUpIfAlreadyGranted();
-    ensureGooglePlacesReady();
+    ensureGooglePlacesReady().catch(() => {});
 
     const citySlug = this.getCitySlugFromRoute();
     if (citySlug) {

--- a/src/AppLayout.js
+++ b/src/AppLayout.js
@@ -2,7 +2,7 @@
  * Layout component for the main app shell: header, main (map), asides, modals.
  * Receives state and handlers from App to keep App.js focused on state and logic.
  */
-import React, { Suspense, useMemo } from 'react';
+import React, { Suspense } from 'react';
 import PropTypes from 'prop-types';
 import AboutModal from './AboutModal.js';
 import PrivacyPolicyModal from './PrivacyPolicy.jsx';
@@ -25,12 +25,13 @@ export default function AppLayout({
   seoPageTitle,
   cityCanonicalSlug,
 }) {
-  const citySwitcherMapCenter = useMemo(() => {
-    const vp = typeof handlers.getMapViewport === 'function' ? handlers.getMapViewport() : null;
-    const lat = vp && Number.isFinite(vp.lat) ? vp.lat : state.lat;
-    const lng = vp && Number.isFinite(vp.lng) ? vp.lng : state.lng;
-    return Number.isFinite(lat) && Number.isFinite(lng) ? { lat, lng } : null;
-  }, [handlers.getMapViewport, state.lat, state.lng]);
+  const vp = typeof handlers.getMapViewport === 'function' ? handlers.getMapViewport() : null;
+  const citySwitcherLat = vp && Number.isFinite(vp.lat) ? vp.lat : state.lat;
+  const citySwitcherLng = vp && Number.isFinite(vp.lng) ? vp.lng : state.lng;
+  const citySwitcherMapCenter =
+    Number.isFinite(citySwitcherLat) && Number.isFinite(citySwitcherLng)
+      ? { lat: citySwitcherLat, lng: citySwitcherLng }
+      : null;
 
   return (
     <div

--- a/src/AppLayout.js
+++ b/src/AppLayout.js
@@ -2,7 +2,7 @@
  * Layout component for the main app shell: header, main (map), asides, modals.
  * Receives state and handlers from App to keep App.js focused on state and logic.
  */
-import React, { Suspense } from 'react';
+import React, { Suspense, useMemo } from 'react';
 import PropTypes from 'prop-types';
 import AboutModal from './AboutModal.js';
 import PrivacyPolicyModal from './PrivacyPolicy.jsx';
@@ -25,6 +25,13 @@ export default function AppLayout({
   seoPageTitle,
   cityCanonicalSlug,
 }) {
+  const citySwitcherMapCenter = useMemo(() => {
+    const vp = typeof handlers.getMapViewport === 'function' ? handlers.getMapViewport() : null;
+    const lat = vp && Number.isFinite(vp.lat) ? vp.lat : state.lat;
+    const lng = vp && Number.isFinite(vp.lng) ? vp.lng : state.lng;
+    return Number.isFinite(lat) && Number.isFinite(lng) ? { lat, lng } : null;
+  }, [handlers.getMapViewport, state.lat, state.lng]);
+
   return (
     <div
       id="ciclomapa"
@@ -44,30 +51,28 @@ export default function AppLayout({
 
       <div className="flex">
         <main className="relative w-full" id="main-map" aria-label="Mapa">
-          {!(IS_MOBILE && state.isDirectionsPanelOpen) && (
-            <header id="topbar-wrapper" aria-label="Barra superior">
-              <TopBar
-                title={state.area}
-                lastUpdate={state.dataUpdatedAt}
-                lat={state.lat}
-                lng={state.lng}
-                z={state.zoom}
-                getViewport={handlers.getMapViewport}
-                downloadData={handlers.downloadData}
-                onMapMoved={handlers.onMapMoved}
-                forceUpdate={handlers.forceUpdate}
-                isSidebarOpen={state.isSidebarOpen}
-                toggleSidebar={handlers.toggleSidebar}
-                embedMode={state.embedMode}
-                debugMode={state.debugMode}
-                openAboutModal={handlers.openAboutModal}
-                isDarkMode={state.isDarkMode}
-                toggleTheme={handlers.toggleTheme}
-                loading={state.loading}
-                cancelDataLoad={handlers.cancelDataLoad}
-              />
-            </header>
-          )}
+          <header id="topbar-wrapper" aria-label="Barra superior">
+            <TopBar
+              title={state.area}
+              lastUpdate={state.dataUpdatedAt}
+              lat={state.lat}
+              lng={state.lng}
+              z={state.zoom}
+              getViewport={handlers.getMapViewport}
+              downloadData={handlers.downloadData}
+              onMapMoved={handlers.onMapMoved}
+              forceUpdate={handlers.forceUpdate}
+              isSidebarOpen={state.isSidebarOpen}
+              toggleSidebar={handlers.toggleSidebar}
+              embedMode={state.embedMode}
+              debugMode={state.debugMode}
+              openAboutModal={handlers.openAboutModal}
+              isDarkMode={state.isDarkMode}
+              toggleTheme={handlers.toggleTheme}
+              loading={state.loading}
+              cancelDataLoad={handlers.cancelDataLoad}
+            />
+          </header>
           {state.mapBootReady ? (
             <Map
               key={state.mapKey}
@@ -137,30 +142,22 @@ export default function AppLayout({
 
       <Suspense fallback={null}>
         <CitySwitcherModal
-          mapCenter={(() => {
-            const vp =
-              typeof handlers.getMapViewport === 'function' ? handlers.getMapViewport() : null;
-            const lat = vp && Number.isFinite(vp.lat) ? vp.lat : state.lat;
-            const lng = vp && Number.isFinite(vp.lng) ? vp.lng : state.lng;
-            return Number.isFinite(lat) && Number.isFinite(lng) ? { lat, lng } : null;
-          })()}
+          mapCenter={citySwitcherMapCenter}
           onPlacesResultSelected={handlers.handleGlobalSearchPlaceSelect}
           onCatalogCityPicked={handlers.clearGlobalSearchPin}
           onFavoritesChanged={handlers.handleFavoritesChanged}
         />
       </Suspense>
 
-      {!(IS_MOBILE && state.isDirectionsPanelOpen) && (
-        <nav aria-label="Camadas do mapa">
-          <LayersBar
-            layers={state.layers}
-            onLayersChange={handlers.onLayersChange}
-            embedMode={state.embedMode}
-            isDarkMode={state.isDarkMode}
-            openLayersLegendModal={handlers.openLayersLegendModal}
-          />
-        </nav>
-      )}
+      <nav aria-label="Camadas do mapa">
+        <LayersBar
+          layers={state.layers}
+          onLayersChange={handlers.onLayersChange}
+          embedMode={state.embedMode}
+          isDarkMode={state.isDarkMode}
+          openLayersLegendModal={handlers.openLayersLegendModal}
+        />
+      </nav>
 
       <aside aria-label="Painel de camadas">
         <LayersPanel
@@ -246,7 +243,6 @@ AppLayout.propTypes = {
     hideUI: PropTypes.bool,
     hideUIFromUrl: PropTypes.bool,
     isSidebarOpen: PropTypes.bool,
-    isDirectionsPanelOpen: PropTypes.bool,
     area: PropTypes.string,
     dataUpdatedAt: PropTypes.string,
     lat: PropTypes.number,

--- a/src/CitySwitcherModal.test.tsx
+++ b/src/CitySwitcherModal.test.tsx
@@ -1,7 +1,7 @@
 import React from 'react';
 import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
-import { MemoryRouter, Route, Routes, useLocation } from 'react-router-dom';
+import { MemoryRouter, Route, Routes, useLocation, useNavigate } from 'react-router-dom';
 import Storage from './Storage.js';
 import { slugify } from './utils/utils.js';
 import { getCanonicalCitySlug } from './config/citySlugCatalog.js';
@@ -81,6 +81,19 @@ function renderOpenPicker(initialPath = '/curitiba') {
   );
 }
 
+function CitySwitcherStaggerTestHost() {
+  const navigate = useNavigate();
+
+  return (
+    <>
+      <button type="button" data-testid="open-city-picker" onClick={() => navigate('?buscar')}>
+        Open city picker
+      </button>
+      <CitySwitcherModal />
+    </>
+  );
+}
+
 it('renders city picker dialog with expected regions when open', async () => {
   renderOpenPicker('/curitiba');
 
@@ -90,6 +103,29 @@ it('renders city picker dialog with expected regions when open', async () => {
     expect(document.querySelector('a[data-city-slug="sao-paulo"]')).toBeInstanceOf(
       HTMLAnchorElement
     );
+  });
+});
+
+it('stagger-enter runs only on the first city picker open', async () => {
+  const user = userEvent.setup();
+  render(
+    <MemoryRouter initialEntries={['/curitiba', '/curitiba?buscar']} initialIndex={1}>
+      <Routes>
+        <Route path="/:city" element={<CitySwitcherStaggerTestHost />} />
+      </Routes>
+    </MemoryRouter>
+  );
+
+  await waitFor(() => {
+    expect(document.querySelector('.city-switcher-modal__staggerEnter')).not.toBeNull();
+  });
+
+  await user.click(screen.getByTestId('city-switcher-close'));
+  await user.click(screen.getByTestId('open-city-picker'));
+
+  await waitFor(() => {
+    expect(screen.getByTestId('city-switcher-dialog')).toBeInTheDocument();
+    expect(document.querySelector('.city-switcher-modal__staggerEnter')).toBeNull();
   });
 });
 

--- a/src/CitySwitcherModal.tsx
+++ b/src/CitySwitcherModal.tsx
@@ -28,7 +28,7 @@ import {
   SUPPORTED_COUNTRY_LABEL_PT_BY_CODE,
 } from './config/constants.js';
 import { appendKmUnit } from './utils/routeUtils.js';
-import { getAreaStringFromResultLike } from './googlePlacesClient.js';
+import { getAreaStringFromResultLike, getPlacesSearchUserMessage } from './googlePlacesClient.js';
 import { PlacesAutocompleteOptionLabel } from './GooglePlacesGeocoder.js';
 import {
   geocodePlacesSuggestionToResult,
@@ -656,6 +656,7 @@ function usePlacesAutocompleteSearch({
 }) {
   const [suggestions, setSuggestions] = useState<unknown[]>([]);
   const [loading, setLoading] = useState(false);
+  const [searchError, setSearchError] = useState<string | null>(null);
   const debounceTimerRef = useRef<number | null>(null);
   const requestSeqRef = useRef(0);
   const getOptionsRef = useRef(getAutocompleteOptions);
@@ -668,6 +669,7 @@ function usePlacesAutocompleteSearch({
       debounceTimerRef.current = null;
     }
     setSuggestions([]);
+    setSearchError(null);
     setLoading(false);
   }, []);
 
@@ -681,12 +683,14 @@ function usePlacesAutocompleteSearch({
       if (trimmed.length < PLACES_AUTOCOMPLETE_MIN_QUERY_LENGTH) {
         requestSeqRef.current += 1;
         setSuggestions([]);
+        setSearchError(null);
         setLoading(false);
         return;
       }
       requestSeqRef.current += 1;
       const scheduledSeq = requestSeqRef.current;
       setLoading(true);
+      setSearchError(null);
       debounceTimerRef.current = window.setTimeout(async () => {
         debounceTimerRef.current = null;
         if (scheduledSeq !== requestSeqRef.current) return;
@@ -694,10 +698,12 @@ function usePlacesAutocompleteSearch({
           const results = await searchPlacesForAutocomplete(trimmed, getOptionsRef.current());
           if (scheduledSeq !== requestSeqRef.current) return;
           setSuggestions(Array.isArray(results) ? results : []);
+          setSearchError(null);
         } catch (e) {
           if (scheduledSeq !== requestSeqRef.current) return;
           console.warn(CITY_SWITCHER_LOG_PREFIX, 'places search failed', e);
           setSuggestions([]);
+          setSearchError(getPlacesSearchUserMessage(e));
         } finally {
           if (scheduledSeq === requestSeqRef.current) {
             setLoading(false);
@@ -716,7 +722,7 @@ function usePlacesAutocompleteSearch({
     };
   }, []);
 
-  return { suggestions, loading, scheduleSearch, clearResults } as const;
+  return { suggestions, loading, searchError, scheduleSearch, clearResults } as const;
 }
 
 function useCityPickerFocusAndRestore({
@@ -1206,6 +1212,7 @@ function CitySwitcherModal({
   const {
     suggestions: placesSuggestions,
     loading: placesSearchLoading,
+    searchError: placesSearchError,
     scheduleSearch: schedulePlacesSearch,
     clearResults: clearPlacesSearch,
   } = usePlacesAutocompleteSearch({
@@ -1541,6 +1548,10 @@ function CitySwitcherModal({
               {placesSearchLoading ? (
                 <p className="city-switcher-modal__placeSearchStatus px-3.5 py-4 text-sm opacity-75">
                   Buscando…
+                </p>
+              ) : placesSearchError ? (
+                <p className="city-switcher-modal__placeSearchStatus px-3.5 py-4 text-sm text-amber-200/90">
+                  {placesSearchError}
                 </p>
               ) : placeSuggestionList.length === 0 ? (
                 <p className="city-switcher-modal__placeSearchStatus px-3.5 py-4 text-sm opacity-75">

--- a/src/CitySwitcherModal.tsx
+++ b/src/CitySwitcherModal.tsx
@@ -60,6 +60,17 @@ const CITY_SWITCHER_STATS_KM_CACHE_KEY = 'ciclomapa_city_switcher_stats_km_v3';
 const CITY_PICKER_INPUT_SELECTOR =
   '.city-switcher-modal__geocoderMount .city-switcher-global-search input';
 
+/** First city-picker open per page load: stagger-enter on catalog / favorites / recents. */
+const STAGGER_ENTER_CLASS = 'city-switcher-modal__staggerEnter';
+
+function withStaggerEnterClass(className: string, enabled: boolean): string {
+  return enabled ? `${className} ${STAGGER_ENTER_CLASS}` : className;
+}
+
+function staggerEnterStyle(index: number, enabled: boolean): React.CSSProperties | undefined {
+  return enabled ? ({ '--city-content-stagger': index } as React.CSSProperties) : undefined;
+}
+
 /** Responsive columns for catalog cities, favorites, and recents (mobile: single column via CSS). */
 const CITY_SWITCHER_CARD_GRID_CLASS =
   'city-switcher-modal__citiesGrid grid grid-cols-2 gap-2.5 lg:grid-cols-3 xl:grid-cols-4 2xl:grid-cols-3';
@@ -999,12 +1010,14 @@ function CityInfraMiniRingPlaceholder() {
 function CityPickerCityCard({
   city,
   stagger,
+  shouldStaggerEnter,
   to,
   onActivate,
   infraLayers,
 }: {
   city: CityPickerRowModel;
   stagger: number;
+  shouldStaggerEnter: boolean;
   to: string;
   onActivate: () => void;
   infraLayers: CitySwitcherInfraLayer[];
@@ -1016,8 +1029,8 @@ function CityPickerCityCard({
 
   return (
     <div
-      className="city-switcher-modal__cityCardWrap city-switcher-modal__staggerEnter"
-      style={{ '--city-content-stagger': stagger } as React.CSSProperties}
+      className={withStaggerEnterClass('city-switcher-modal__cityCardWrap', shouldStaggerEnter)}
+      style={staggerEnterStyle(stagger, shouldStaggerEnter)}
       role="listitem"
     >
       <Link
@@ -1194,6 +1207,26 @@ function CitySwitcherModal({
   const [searchParams] = useSearchParams();
   const navigate = useNavigate();
   const isCityPickerOpen = searchParams.has('buscar');
+  const cityPickerStaggerPlayedRef = useRef(false);
+  const shouldStaggerEnterRef = useRef<boolean | null>(null);
+
+  useEffect(() => {
+    if (!isCityPickerOpen) {
+      shouldStaggerEnterRef.current = null;
+    }
+  }, [isCityPickerOpen]);
+
+  const shouldStaggerEnter = (() => {
+    if (!isCityPickerOpen) return false;
+    if (shouldStaggerEnterRef.current === null) {
+      const firstOpenThisSession = !cityPickerStaggerPlayedRef.current;
+      shouldStaggerEnterRef.current = firstOpenThisSession;
+      if (firstOpenThisSession) {
+        cityPickerStaggerPlayedRef.current = true;
+      }
+    }
+    return shouldStaggerEnterRef.current;
+  })();
 
   useEffect(() => {
     if (!isCityPickerOpen) {
@@ -1522,8 +1555,11 @@ function CitySwitcherModal({
                     return (
                       <div
                         key={s.id || s.properties?.place_id || `${s.place_name}-${i}`}
-                        className="city-switcher-modal__cityCardWrap city-switcher-modal__staggerEnter"
-                        style={{ '--city-content-stagger': i } as React.CSSProperties}
+                        className={withStaggerEnterClass(
+                          'city-switcher-modal__cityCardWrap',
+                          shouldStaggerEnter
+                        )}
+                        style={staggerEnterStyle(i, shouldStaggerEnter)}
                         role="listitem"
                       >
                         <div className="city-switcher-modal__placeSearchResultCard">
@@ -1600,8 +1636,8 @@ function CitySwitcherModal({
               data-testid="city-switcher-favorites"
             >
               <div
-                className="city-switcher-modal__staggerEnter"
-                style={{ '--city-content-stagger': contentStaggerIndex++ } as React.CSSProperties}
+                className={shouldStaggerEnter ? STAGGER_ENTER_CLASS : undefined}
+                style={staggerEnterStyle(contentStaggerIndex++, shouldStaggerEnter)}
               >
                 <div className="city-switcher-modal__sectionTitle flex items-center gap-1 px-3.5 py-4 text-xs tracking-wide text-white opacity-75">
                   {/* <HiHeartIcon
@@ -1619,10 +1655,11 @@ function CitySwitcherModal({
                 {favorites.map((fav) => (
                   <div
                     key={fav.id}
-                    className="city-switcher-modal__cityCardWrap city-switcher-modal__staggerEnter"
-                    style={
-                      { '--city-content-stagger': contentStaggerIndex++ } as React.CSSProperties
-                    }
+                    className={withStaggerEnterClass(
+                      'city-switcher-modal__cityCardWrap',
+                      shouldStaggerEnter
+                    )}
+                    style={staggerEnterStyle(contentStaggerIndex++, shouldStaggerEnter)}
                     role="listitem"
                   >
                     <button
@@ -1682,8 +1719,8 @@ function CitySwitcherModal({
               data-testid="city-switcher-recent"
             >
               <div
-                className="city-switcher-modal__staggerEnter"
-                style={{ '--city-content-stagger': contentStaggerIndex++ } as React.CSSProperties}
+                className={shouldStaggerEnter ? STAGGER_ENTER_CLASS : undefined}
+                style={staggerEnterStyle(contentStaggerIndex++, shouldStaggerEnter)}
               >
                 <div className="city-switcher-modal__sectionTitle flex items-center gap-1 px-3.5 py-4 text-xs tracking-wide text-white opacity-75">
                   {/* <HiMiniClockIcon
@@ -1701,10 +1738,11 @@ function CitySwitcherModal({
                 {recentItemsDisplayed.map((item) => (
                   <div
                     key={item.id}
-                    className="city-switcher-modal__cityCardWrap city-switcher-modal__staggerEnter"
-                    style={
-                      { '--city-content-stagger': contentStaggerIndex++ } as React.CSSProperties
-                    }
+                    className={withStaggerEnterClass(
+                      'city-switcher-modal__cityCardWrap',
+                      shouldStaggerEnter
+                    )}
+                    style={staggerEnterStyle(contentStaggerIndex++, shouldStaggerEnter)}
                     role="listitem"
                   >
                     {item.type === 'city' && item.citySlug ? (
@@ -1808,10 +1846,8 @@ function CitySwitcherModal({
                   data-country-code={group.countryCode}
                 >
                   <div
-                    className="city-switcher-modal__staggerEnter"
-                    style={
-                      { '--city-content-stagger': contentStaggerIndex++ } as React.CSSProperties
-                    }
+                    className={shouldStaggerEnter ? STAGGER_ENTER_CLASS : undefined}
+                    style={staggerEnterStyle(contentStaggerIndex++, shouldStaggerEnter)}
                   >
                     <div className="city-switcher-modal__sectionTitle px-3.5 py-4 text-xs tracking-wide text-white opacity-75">
                       {group.countryLabel}
@@ -1823,6 +1859,7 @@ function CitySwitcherModal({
                         key={c.canonicalSlug}
                         city={c}
                         stagger={contentStaggerIndex++}
+                        shouldStaggerEnter={shouldStaggerEnter}
                         to={`/${encodeURIComponent(c.canonicalSlug)}`}
                         onActivate={() => onCityLinkActivate(c, 'top')}
                         infraLayers={infraLayersForMiniPie}

--- a/src/CitySwitcherModal.tsx
+++ b/src/CitySwitcherModal.tsx
@@ -1,4 +1,12 @@
-import React, { useCallback, useEffect, useLayoutEffect, useMemo, useRef, useState } from 'react';
+import React, {
+  memo,
+  useCallback,
+  useEffect,
+  useLayoutEffect,
+  useMemo,
+  useRef,
+  useState,
+} from 'react';
 import { createPortal } from 'react-dom';
 import { Link, useNavigate, useParams, useSearchParams } from 'react-router-dom';
 import { HiMiniClock, HiOutlineXMark, HiOutlineHeart, HiHeart } from 'react-icons/hi2';
@@ -595,11 +603,11 @@ function usePreloadedStatsTotalsByCanonicalSlug(cityObjs: StatsCityLike[], isPic
     const myGeneration = effectGenerationRef.current;
     const list = Array.isArray(cityObjs) ? cityObjs : [];
 
-    setIsLoadingTotals(true);
     const applyCacheToState = () => {
       if (effectGenerationRef.current !== myGeneration) return;
       setStatsTotalsByCanonicalSlug(new Map(statsTotalsByCanonicalSlugCache));
     };
+    setIsLoadingTotals(true);
     if (!statsTotalsLoadPromise) {
       statsTotalsLoadPromise = preloadStatsTotalsForCities(list, {
         onCacheUpdate: applyCacheToState,
@@ -1457,10 +1465,14 @@ function CitySwitcherModal({
 
   let contentStaggerIndex = 0;
 
+  if (!isCityPickerOpen) {
+    return null;
+  }
+
   /** Portaled to `document.body` so `#ciclomapa { overflow: hidden }` does not clip this overlay. */
   const modalTree = (
     <div
-      className={`city-switcher-modal fixed inset-0${isCityPickerOpen ? ' city-switcher-modal--open' : ''}`}
+      className="city-switcher-modal fixed inset-0 city-switcher-modal--open"
       role="dialog"
       aria-modal="true"
       data-testid="city-switcher-dialog"
@@ -1910,4 +1922,25 @@ export function replaceCitySwitcherStatsCacheForTest(
   );
 }
 
-export default CitySwitcherModal;
+type MapCenter = { lat: number; lng: number };
+
+function mapCenterEqual(a: MapCenter | null | undefined, b: MapCenter | null | undefined): boolean {
+  if (a === b) return true;
+  if (!a || !b) return !a && !b;
+  return a.lat === b.lat && a.lng === b.lng;
+}
+
+function citySwitcherModalPropsAreEqual(
+  prev: CitySwitcherModalProps,
+  next: CitySwitcherModalProps
+): boolean {
+  return (
+    mapCenterEqual(prev.mapCenter, next.mapCenter) &&
+    prev.placesAutocompleteOptions === next.placesAutocompleteOptions &&
+    prev.onPlacesResultSelected === next.onPlacesResultSelected &&
+    prev.onCatalogCityPicked === next.onCatalogCityPicked &&
+    prev.onFavoritesChanged === next.onFavoritesChanged
+  );
+}
+
+export default memo(CitySwitcherModal, citySwitcherModalPropsAreEqual);

--- a/src/DirectionsPanel.css
+++ b/src/DirectionsPanel.css
@@ -6,6 +6,18 @@
   left: var(--spacing-panel);
   width: var(--spacing-panel-width);
   z-index: 1;
+  transition:
+    transform var(--motion-duration-normal) ease-out,
+    opacity var(--motion-duration-normal) ease-out;
+  transform: translateY(-10%);
+  opacity: 0;
+  pointer-events: none;
+
+  &.directions-panel-open {
+    transform: translateY(0);
+    opacity: 1;
+    pointer-events: auto;
+  }
 
   #fromGeocoder {
     z-index: 1001;
@@ -267,7 +279,7 @@ body.theme-light {
   }
 }
 
-/* Mobile: bottom sheet slides up from below */
+/* Mobile: bottom sheet layout */
 @media (min-width: 320px) and (max-width: 480px) {
   #directionsPanel {
     z-index: 1000;
@@ -276,18 +288,7 @@ body.theme-light {
     top: auto;
     bottom: calc(var(--radius-md) + env(safe-area-inset-bottom, 0px));
     width: calc(100% - 2 * var(--radius-md));
-    transition:
-      transform var(--motion-duration-normal) ease-out,
-      opacity var(--motion-duration-normal) ease-out;
     transform: translateY(calc(100% + 2 * var(--radius-md)));
-    opacity: 0;
-    pointer-events: none;
-  }
-
-  #directionsPanel.directions-panel-open {
-    transform: translateY(0);
-    opacity: 1;
-    pointer-events: auto;
   }
 
   /* Keep TopBar / LayersBar mounted; hide while the route sheet is open (avoids costly unmount). */

--- a/src/DirectionsPanel.css
+++ b/src/DirectionsPanel.css
@@ -276,10 +276,9 @@ body.theme-light {
     top: auto;
     bottom: calc(var(--radius-md) + env(safe-area-inset-bottom, 0px));
     width: calc(100% - 2 * var(--radius-md));
-    border-radius: var(--radius-md) var(--radius-md) 0 0;
     transition:
-      transform var(--motion-duration-normal) ease-in-out,
-      opacity var(--motion-duration-normal) ease-in-out;
+      transform var(--motion-duration-normal) ease-out,
+      opacity var(--motion-duration-normal) ease-out;
     transform: translateY(calc(100% + 2 * var(--radius-md)));
     opacity: 0;
     pointer-events: none;
@@ -289,6 +288,12 @@ body.theme-light {
     transform: translateY(0);
     opacity: 1;
     pointer-events: auto;
+  }
+
+  /* Keep TopBar / LayersBar mounted; hide while the route sheet is open (avoids costly unmount). */
+  #ciclomapa:has(#directionsPanel.directions-panel-open) #topbar-wrapper,
+  #ciclomapa:has(#directionsPanel.directions-panel-open) nav[aria-label='Camadas do mapa'] {
+    display: none;
   }
 
   #directionsPanel .ant-input-affix-wrapper {

--- a/src/DirectionsPanel.js
+++ b/src/DirectionsPanel.js
@@ -1270,20 +1270,6 @@ class DirectionsPanel extends Component {
               <div className="mt-2 text-sm text-amber-200/90">{this.state.placesSearchError}</div>
             )}
 
-            {!showResultsOnMobile && (
-              <Button
-                type="primary"
-                size="large"
-                block
-                className="mt-3"
-                onClick={() => this.requestDirectionsCalculation()}
-                loading={directionsLoading}
-                disabled={!this.props.fromPoint || !this.props.toPoint}
-              >
-                Calcular rota
-              </Button>
-            )}
-
             {directionsLoading && (
               <div
                 id="directionsPanel--results"

--- a/src/DirectionsPanel.js
+++ b/src/DirectionsPanel.js
@@ -20,6 +20,7 @@ import {
   ENABLE_AUTOFILL_ORIGIN_ON_PANEL_OPEN,
 } from './config/constants.js';
 import DirectionsManager from './DirectionsManager.js';
+import { flyMapTo } from './features/map/mapCamera.js';
 import userLocationCache from './features/geolocation/userLocationCache.js';
 import LocationSearchInput from './features/directions/components/LocationSearchInput.js';
 import RouteSortDropdown from './features/directions/components/RouteSortDropdown.js';
@@ -431,10 +432,9 @@ class DirectionsPanel extends Component {
       this.props.onFromPointChange(result);
 
       if (fromAutocomplete && this.props.map) {
-        this.props.map.flyTo({
+        flyMapTo(this.props.map, {
           center: result.result.center,
           zoom: Math.max(this.props.map.getZoom(), 16),
-          duration: 1500,
         });
       }
 

--- a/src/DirectionsPanel.js
+++ b/src/DirectionsPanel.js
@@ -31,6 +31,7 @@ import {
   getAreaStringFromResultLike,
   getCityFromResultLike,
   getGooglePlacesGeocoder,
+  getPlacesSearchUserMessage,
   getShortAddressFromResultLike,
 } from './googlePlacesClient.js';
 import { filterFavoritesByQuery, filterFavoritesForArea } from './favoritesStore';
@@ -64,6 +65,7 @@ class DirectionsPanel extends Component {
       fromSearchLoading: false,
       toSearchLoading: false,
       cityValidationError: null,
+      placesSearchError: null,
       geolocatingInput: null,
     };
 
@@ -276,12 +278,15 @@ class DirectionsPanel extends Component {
     const trimmed = (value ?? '').trim();
     if (!trimmed || trimmed.length < PLACES_AUTOCOMPLETE_MIN_QUERY_LENGTH) {
       this.setFavoriteSuggestions(inputType, trimmed);
+      this.setState({ placesSearchError: null });
       return;
     }
 
-    this.setState({ [`${inputType}Suggestions`]: [] });
-
-    this.setState({ [`${inputType}SearchLoading`]: true });
+    this.setState({
+      [`${inputType}Suggestions`]: [],
+      [`${inputType}SearchLoading`]: true,
+      placesSearchError: null,
+    });
 
     try {
       const results = await searchPlacesForAutocomplete(
@@ -292,12 +297,14 @@ class DirectionsPanel extends Component {
       this.setState({
         [`${inputType}Suggestions`]: results,
         [`${inputType}SearchLoading`]: false,
+        placesSearchError: null,
       });
     } catch (error) {
       console.error(`${inputType} search error:`, error);
       this.setState({
         [`${inputType}Suggestions`]: [],
         [`${inputType}SearchLoading`]: false,
+        placesSearchError: getPlacesSearchUserMessage(error),
       });
     }
   }
@@ -1257,6 +1264,24 @@ class DirectionsPanel extends Component {
                   aria-label="Trocar origem e destino"
                 />
               </div>
+            )}
+
+            {!showResultsOnMobile && this.state.placesSearchError && (
+              <div className="mt-2 text-sm text-amber-200/90">{this.state.placesSearchError}</div>
+            )}
+
+            {!showResultsOnMobile && (
+              <Button
+                type="primary"
+                size="large"
+                block
+                className="mt-3"
+                onClick={() => this.requestDirectionsCalculation()}
+                loading={directionsLoading}
+                disabled={!this.props.fromPoint || !this.props.toPoint}
+              >
+                Calcular rota
+              </Button>
             )}
 
             {directionsLoading && (

--- a/src/DirectionsPanel.js
+++ b/src/DirectionsPanel.js
@@ -163,10 +163,6 @@ class DirectionsPanel extends Component {
       if (this.props.onDirectionsPanelToggle) {
         this.props.onDirectionsPanelToggle(true);
       }
-    } else {
-      if (this.props.onDirectionsPanelToggle) {
-        this.props.onDirectionsPanelToggle(!this.state.collapsed);
-      }
     }
   }
 
@@ -407,10 +403,15 @@ class DirectionsPanel extends Component {
       this.cancelActiveGeolocation();
     }
 
+    if (this.blurTimeout) {
+      clearTimeout(this.blurTimeout);
+      this.blurTimeout = null;
+    }
+
     this.setState({
       [`${inputType}SearchValue`]: '',
-      [`${inputType}Suggestions`]: [],
       cityValidationError: null,
+      focusedInput: inputType,
     });
 
     // Clear the corresponding point
@@ -421,6 +422,8 @@ class DirectionsPanel extends Component {
       this.props.onToPointChange(null);
       this.removeMarker('to');
     }
+
+    this.setFavoriteSuggestions(inputType, '');
   }
 
   handleGeolocation(inputType, isAutoTriggered = false) {
@@ -964,6 +967,12 @@ class DirectionsPanel extends Component {
 
   handleInputFocus(inputType) {
     console.debug(`Input focused: ${inputType}`);
+
+    if (this.blurTimeout) {
+      clearTimeout(this.blurTimeout);
+      this.blurTimeout = null;
+    }
+
     this.setState({ focusedInput: inputType });
 
     const currentValue = this.state[`${inputType}SearchValue`] || '';
@@ -991,14 +1000,22 @@ class DirectionsPanel extends Component {
       // Delay to make sure that if the next click was on the map, it'll set the point
       // Also check if the blur was caused by clicking on a suggestion
       this.blurTimeout = setTimeout(() => {
-        // Check if the active element is still within the autocomplete dropdown
+        // User may have focused the other origin/destination field in the meantime
+        if (this.state.focusedInput !== inputType) {
+          this.blurTimeout = null;
+          return;
+        }
+
         const activeElement = document.activeElement;
         const isDropdownActive =
           activeElement &&
           (activeElement.closest('.ant-select-dropdown') ||
             activeElement.closest('.ant-select-item'));
+        const isRoutePointsInputFocused =
+          activeElement?.tagName === 'INPUT' &&
+          Boolean(activeElement.closest('.cm-route-points__inputs'));
 
-        if (!isDropdownActive) {
+        if (!isDropdownActive && !isRoutePointsInputFocused) {
           this.setState({ focusedInput: null });
           console.debug('Focus cleared, resetting cursor');
 
@@ -1007,7 +1024,7 @@ class DirectionsPanel extends Component {
             this.props.onRouteModeChange(false);
           }
         } else {
-          console.debug('Blur ignored - dropdown is active');
+          console.debug('Blur ignored - dropdown or route input is active');
         }
 
         this.blurTimeout = null;

--- a/src/DirectionsPanel.js
+++ b/src/DirectionsPanel.js
@@ -1107,6 +1107,11 @@ class DirectionsPanel extends Component {
 
     const routes = sortedRoutes.slice(0, HYBRID_MAX_RESULTS);
     const showResultsOnMobile = IS_MOBILE && (directions || directionsLoading);
+    const panelOpenClass = !this.state.collapsed
+      ? `directions-panel-open ${
+          showResultsOnMobile ? 'directions-panel-open--results' : 'directions-panel-open--planning'
+        }`
+      : '';
 
     return (
       <>
@@ -1121,22 +1126,7 @@ class DirectionsPanel extends Component {
         )}
         <div
           id="directionsPanel"
-          className={`
-                        cm-panel glass-bg fixed text-white cursor-pointer
-                        ${
-                          IS_MOBILE
-                            ? this.state.collapsed
-                              ? ''
-                              : `directions-panel-open ${
-                                  showResultsOnMobile
-                                    ? 'directions-panel-open--results'
-                                    : 'directions-panel-open--planning'
-                                }`
-                            : this.state.collapsed
-                              ? 'hidden'
-                              : ''
-                        }
-                    `}
+          className={`cm-panel glass-bg fixed text-white cursor-pointer ${panelOpenClass}`}
         >
           <div className="cm-panel__body p-4">
             <div
@@ -1171,7 +1161,12 @@ class DirectionsPanel extends Component {
               ) : (
                 // Default header
                 <>
-                  <h3 className="font-semibold flex items-center mb-0">Planejar rota</h3>
+                  <h3 className="font-semibold flex items-center gap-2 mb-0">
+                    {!IS_MOBILE && (
+                      <LuBike className="text-lg flex-shrink-0 opacity-90" aria-hidden />
+                    )}
+                    Planejar rota
+                  </h3>
 
                   <div
                     className="flex items-start -mr-1 flex-shrink-0 opacity-50"

--- a/src/GooglePlacesGeocoder.js
+++ b/src/GooglePlacesGeocoder.js
@@ -331,9 +331,15 @@ export function PlacesAutocompleteOptionLabel({
 /** One shared inject so HMR / concurrent callers do not append multiple script tags. */
 let googleMapsScriptReadyPromise = null;
 
+function createPlacesError(message, code) {
+  const error = new Error(message);
+  error.code = code;
+  return error;
+}
+
 function ensureGoogleMapsScriptLoaded(apiKey, language, region) {
   if (typeof window === 'undefined') {
-    return Promise.reject(new Error('Google Maps API not available (SSR)'));
+    return Promise.reject(createPlacesError('Google Maps API not available (SSR)', 'SSR'));
   }
   if (window.google?.maps) {
     return Promise.resolve();
@@ -351,7 +357,7 @@ function ensureGoogleMapsScriptLoaded(apiKey, language, region) {
       script.onload = () => resolve();
       script.onerror = () => {
         googleMapsScriptReadyPromise = null;
-        reject(new Error('Failed to load Google Maps API'));
+        reject(createPlacesError('Failed to load Google Maps API', 'SCRIPT_LOAD_FAILED'));
       };
       document.head.appendChild(script);
     });
@@ -381,7 +387,7 @@ class GooglePlacesGeocoder {
 
   async loadGoogleMapsAPI() {
     if (!this.apiKey) {
-      throw new Error('Google Maps API key is missing');
+      throw createPlacesError('Google Maps API key is missing', 'MISSING_API_KEY');
     }
     await ensureGoogleMapsScriptLoaded(this.apiKey, this.language, this.region);
     await this.initializeServices();
@@ -389,7 +395,7 @@ class GooglePlacesGeocoder {
 
   async initializeServices() {
     if (!window.google?.maps) {
-      throw new Error('Google Maps API not loaded');
+      throw createPlacesError('Google Maps API not loaded', 'NOT_LOADED');
     }
 
     const maps = window.google.maps;
@@ -405,6 +411,10 @@ class GooglePlacesGeocoder {
         const dummyDiv = document.createElement('div');
         this.placesService = new maps.places.PlacesService(dummyDiv);
       }
+
+      if (!this.autocompleteService) {
+        throw createPlacesError('Google Places library not available', 'PLACES_UNAVAILABLE');
+      }
     } catch (error) {
       console.error('Failed to initialize Google Maps services:', error);
       throw error;
@@ -413,7 +423,7 @@ class GooglePlacesGeocoder {
 
   async search(query, options = {}) {
     if (!this.autocompleteService) {
-      throw new Error('Google Places API not initialized');
+      throw createPlacesError('Google Places API not initialized', 'NOT_INITIALIZED');
     }
 
     trackCall({ api: API_TYPES.GOOGLE_PREDICTIONS, details: query });
@@ -438,7 +448,7 @@ class GooglePlacesGeocoder {
     const adminRegionExclude = resolveAdminRegionExcludeFromBlock(options.exclude);
     const excludeCityOnly = Boolean(options.exclude?.bareCity);
 
-    return new Promise((resolve) => {
+    return new Promise((resolve, reject) => {
       this.autocompleteService.getPlacePredictions(request, (predictions, status) => {
         if (status === window.google.maps.places.PlacesServiceStatus.OK && predictions) {
           let filtered = predictions;
@@ -454,15 +464,16 @@ class GooglePlacesGeocoder {
             .slice(0, limit)
             .map((prediction) => this.formatPredictionResult(prediction));
           resolve(formattedResults);
-        } else {
-          if (
-            status !== window.google.maps.places.PlacesServiceStatus.ZERO_RESULTS &&
-            status !== window.google.maps.places.PlacesServiceStatus.OK
-          ) {
-            console.warn('Google Places API error:', status);
-          }
-          resolve([]);
+          return;
         }
+
+        if (status === window.google.maps.places.PlacesServiceStatus.ZERO_RESULTS) {
+          resolve([]);
+          return;
+        }
+
+        console.warn('Google Places API error:', status);
+        reject(createPlacesError(`Google Places API error: ${status}`, status));
       });
     });
   }

--- a/src/LayersLegendModal.js
+++ b/src/LayersLegendModal.js
@@ -11,6 +11,7 @@ import commentIcon from './img/icons/poi-comment-flat.png';
 import { HiOutlineXMark } from 'react-icons/hi2';
 
 import {
+  ENABLE_COMMENTS,
   IS_MOBILE,
   ROUTE_COLORS,
   ROUTE_INFRASTRUCTURE_QUALITY_WEIGHTS,
@@ -380,21 +381,23 @@ class LayersLegendModal extends Component {
                     <h3 className={sectionHeadingClass}>Pontos de interesse</h3>
                     <div className={categoryContainerClasses}>
                       {pontosLayers.map(renderLayer)}
-                      <div className="rounded-xl border border-white border-opacity-10 bg-gray-900 bg-opacity-80 p-4">
-                        <div className="flex gap-4 md:flex-col flex-row">
-                          <div className="flex-shrink-0">
-                            <img className="h-7 w-7 opacity-90" src={commentIcon} alt="" />
-                          </div>
-                          <div className="flex-1 min-w-0">
-                            <h3 className={layerTitleClass}>Comentários da comunidade</h3>
-                            <p className="text-sm text-gray-400 leading-normal mb-0 mt-2">
-                              Enviados por quem usa o CicloMapa, servem para relatar problemas,
-                              sugestões ou observações sobre o local para auxiliar parceiros
-                              editores do OpenStreetMap.
-                            </p>
+                      {ENABLE_COMMENTS && (
+                        <div className="rounded-xl border border-white border-opacity-10 bg-gray-900 bg-opacity-80 p-4">
+                          <div className="flex gap-4 md:flex-col flex-row">
+                            <div className="flex-shrink-0">
+                              <img className="h-7 w-7 opacity-90" src={commentIcon} alt="" />
+                            </div>
+                            <div className="flex-1 min-w-0">
+                              <h3 className={layerTitleClass}>Comentários da comunidade</h3>
+                              <p className="text-sm text-gray-400 leading-normal mb-0 mt-2">
+                                Enviados por quem usa o CicloMapa, servem para relatar problemas,
+                                sugestões ou observações sobre o local para auxiliar parceiros
+                                editores do OpenStreetMap.
+                              </p>
+                            </div>
                           </div>
                         </div>
-                      </div>
+                      )}
                     </div>
                   </div>
                 )}

--- a/src/Map.js
+++ b/src/Map.js
@@ -2771,8 +2771,10 @@ class Map extends Component {
     // Initialize map after style is loaded
     this.initializeMapAfterStyleLoad();
 
-    // Initialize map center
-    const shouldInitializeArea = this.props.zoom >= MAP_AUTOCHANGE_AREA_ZOOM_THRESHOLD;
+    // Initialize map center. Match onMapMoveEnded: mobile never reverse-geocodes
+    // (no live city label), so skip the Mapbox request on startup too.
+    const shouldInitializeArea =
+      !IS_MOBILE && this.props.zoom >= MAP_AUTOCHANGE_AREA_ZOOM_THRESHOLD;
     if (shouldInitializeArea) {
       this.reverseGeocode([this.props.lng, this.props.lat])
         .then((result) => {
@@ -2783,7 +2785,7 @@ class Map extends Component {
           console.debug('Reverse geocoding failed during initialization:', err.message);
         });
     } else {
-      // Preserve map state without forcing an area when zoomed out.
+      // Preserve map state without forcing an area when zoomed out (or on mobile).
       this.syncMapState();
     }
   }

--- a/src/Map.js
+++ b/src/Map.js
@@ -3163,6 +3163,7 @@ class Map extends Component {
   }
 
   newComment() {
+    if (!ENABLE_COMMENTS) return;
     this.setState({ showCommentCursor: true }, () => {
       this.map.once('click', (e) => {
         this.newCommentCoords = e.lngLat;

--- a/src/Map.js
+++ b/src/Map.js
@@ -48,6 +48,7 @@ import debounce from 'lodash.debounce';
 import { getCurrentSunPosition } from './sunPositionUtils';
 import { arrowIconsByLayer, arrowIcons, arrowSdf, iconsMap } from './features/map/icons';
 import { reverseGeocodePlace } from './features/map/mapboxGeocoding.js';
+import { flyMapTo } from './features/map/mapCamera.js';
 import userLocationCache from './features/geolocation/userLocationCache.js';
 
 import './Map.css';
@@ -70,11 +71,9 @@ export function flyMapToCityFocus(map, centerLngLat, placeName) {
     placeName === VITORIA_GEOCODER_PLACE_NAME ? VITORIA_FOCUS_CENTER_LNG_LAT : [lng, lat];
   if (!center || !Number.isFinite(center[0]) || !Number.isFinite(center[1])) return;
 
-  map.flyTo({
+  flyMapTo(map, {
     center,
     zoom: DEFAULT_ZOOM,
-    speed: 2.2,
-    minZoom: 6,
   });
 }
 

--- a/src/Map.js
+++ b/src/Map.js
@@ -207,6 +207,12 @@ class Map extends Component {
   onMapMoveEnded() {
     this.syncMapState();
 
+    // Mobile never shows a live city label from pan/zoom geocoding (top bar is a search
+    // placeholder; analytics sidebar is desktop-only). Skip Mapbox reverse-geocode entirely.
+    if (IS_MOBILE) {
+      return;
+    }
+
     if (this.map.getZoom() > MAP_AUTOCHANGE_AREA_ZOOM_THRESHOLD) {
       const center = this.map.getCenter();
       // Capture when this geocode request was initiated so App can distinguish stale

--- a/src/MapPopups.css
+++ b/src/MapPopups.css
@@ -70,7 +70,7 @@
 
 .theme-dark .route-tooltip-popup.mapboxgl-popup,
 .theme-dark .popup-big.mapboxgl-popup {
-  --popup-bg-color: rgba(0, 0, 0, 0.2);
+  --popup-bg-color: rgba(0, 0, 0, 0.5);
   --popup-text-color: white;
   --popup-text-color-on-primary: black;
 }
@@ -81,7 +81,7 @@
 
 .theme-light .route-tooltip-popup.mapboxgl-popup,
 .theme-light .popup-big.mapboxgl-popup {
-  --popup-bg-color: rgba(255, 255, 255, 0.2);
+  --popup-bg-color: rgba(255, 255, 255, 0.8);
   --popup-text-color: black;
   --popup-text-color-on-primary: white;
 }

--- a/src/MapPopups.js
+++ b/src/MapPopups.js
@@ -458,13 +458,18 @@ class MapPopups {
                     Editar
                 </a>
 
+                ${
+                  ENABLE_COMMENTS
+                    ? `
                 <a  href="#"
                     class="flex-shrink-0 border border-opacity-25 border-${color} px-3 py-1.5 text-sm rounded-full whitespace-nowrap"
                     onClick="document.dispatchEvent(new Event('newComment'));"
                 >
                     ${COMMENT_ICON_SVG}
                     Comentar
-                </a>
+                </a>`
+                    : ''
+                }
                 </div>
             </div>
         `;

--- a/src/PwaUpdateBanner.css
+++ b/src/PwaUpdateBanner.css
@@ -1,0 +1,60 @@
+.pwa-update-banner {
+  transform: translateY(16px);
+  opacity: 0;
+  transition:
+    transform 750ms cubic-bezier(0.16, 1, 0.3, 1),
+    opacity 650ms cubic-bezier(0.16, 1, 0.3, 1);
+  will-change: transform, opacity;
+}
+
+.pwa-update-banner--visible {
+  transform: translateY(0);
+  opacity: 1;
+}
+
+.pwa-update-banner--light {
+  background: #ffffff;
+  border-color: rgba(0, 0, 0, 0.1);
+}
+
+.pwa-update-banner--dark {
+  background: #262626;
+  border-color: rgba(255, 255, 255, 0.1);
+}
+
+.pwa-update-banner__label--light {
+  color: #111827;
+}
+
+.pwa-update-banner__label--dark {
+  color: #ffffff;
+}
+
+.pwa-update-banner--light .pwa-update-banner__close.ant-btn {
+  color: rgba(0, 0, 0, 0.45);
+}
+
+.pwa-update-banner--light .pwa-update-banner__close.ant-btn:hover {
+  color: rgba(0, 0, 0, 0.88) !important;
+  background: rgba(0, 0, 0, 0.06) !important;
+}
+
+.pwa-update-banner--dark .pwa-update-banner__close.ant-btn {
+  color: rgba(255, 255, 255, 0.65);
+}
+
+.pwa-update-banner--dark .pwa-update-banner__close.ant-btn:hover {
+  color: #ffffff !important;
+  background: rgba(255, 255, 255, 0.08) !important;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .pwa-update-banner {
+    transform: none;
+    transition: opacity 250ms ease;
+  }
+
+  .pwa-update-banner--visible {
+    transform: none;
+  }
+}

--- a/src/PwaUpdateBanner.css
+++ b/src/PwaUpdateBanner.css
@@ -1,15 +1,16 @@
-.pwa-update-banner {
-  transform: translateY(16px);
-  opacity: 0;
-  transition:
-    transform 750ms cubic-bezier(0.16, 1, 0.3, 1),
-    opacity 650ms cubic-bezier(0.16, 1, 0.3, 1);
-  will-change: transform, opacity;
+@keyframes pwa-update-banner-in {
+  from {
+    transform: translateY(16px);
+    opacity: 0;
+  }
+  to {
+    transform: translateY(0);
+    opacity: 1;
+  }
 }
 
-.pwa-update-banner--visible {
-  transform: translateY(0);
-  opacity: 1;
+.pwa-update-banner {
+  animation: pwa-update-banner-in 750ms cubic-bezier(0.16, 1, 0.3, 1) both;
 }
 
 .pwa-update-banner--light {
@@ -49,12 +50,16 @@
 }
 
 @media (prefers-reduced-motion: reduce) {
-  .pwa-update-banner {
-    transform: none;
-    transition: opacity 250ms ease;
+  @keyframes pwa-update-banner-in {
+    from {
+      opacity: 0;
+    }
+    to {
+      opacity: 1;
+    }
   }
 
-  .pwa-update-banner--visible {
-    transform: none;
+  .pwa-update-banner {
+    animation: pwa-update-banner-in 250ms ease both;
   }
 }

--- a/src/PwaUpdateBanner.jsx
+++ b/src/PwaUpdateBanner.jsx
@@ -11,56 +11,25 @@ import './PwaUpdateBanner.css';
 const isPwaBannerPreview =
   !IS_PROD && new URLSearchParams(window.location.search).has('pwa-banner');
 
-const TRANSITION_MS = 750;
-
 function hasUpdateToShow() {
   return isPwaBannerPreview || Boolean(getPendingUpdate());
 }
 
 export default function PwaUpdateBanner({ isDarkMode }) {
-  const [visible, setVisible] = useState(() => hasUpdateToShow());
-  const [dismissed, setDismissed] = useState(false);
-  const [mounted, setMounted] = useState(() => hasUpdateToShow());
-  const [active, setActive] = useState(false);
-
-  const shouldShow = visible && !dismissed && hasUpdateToShow();
+  const [open, setOpen] = useState(() => hasUpdateToShow());
 
   useEffect(() => {
     return subscribeToPwaUpdate(() => {
-      if (getPendingUpdate()) {
-        setDismissed(false);
-        setVisible(true);
-      }
+      if (getPendingUpdate()) setOpen(true);
     });
   }, []);
 
-  useEffect(() => {
-    if (shouldShow) {
-      setMounted(true);
-      const frame = requestAnimationFrame(() => {
-        requestAnimationFrame(() => setActive(true));
-      });
-      return () => cancelAnimationFrame(frame);
-    }
-
-    setActive(false);
-    return undefined;
-  }, [shouldShow]);
-
-  useEffect(() => {
-    if (!shouldShow && mounted && !active) {
-      const timer = window.setTimeout(() => setMounted(false), TRANSITION_MS);
-      return () => window.clearTimeout(timer);
-    }
-    return undefined;
-  }, [shouldShow, mounted, active]);
-
-  if (!mounted) {
+  if (!open) {
     return null;
   }
 
   const handleDismiss = () => {
-    setDismissed(true);
+    setOpen(false);
   };
 
   const handleApply = () => {
@@ -75,7 +44,6 @@ export default function PwaUpdateBanner({ isDarkMode }) {
     <div
       className={[
         'pwa-update-banner fixed bottom-2 left-2 right-2 z-[1000] flex min-h-12 items-center gap-2 rounded-lg border px-4 py-3 shadow-md sm:gap-3',
-        active ? 'pwa-update-banner--visible' : '',
         isDarkMode ? 'pwa-update-banner--dark' : 'pwa-update-banner--light',
       ].join(' ')}
       role="status"

--- a/src/PwaUpdateBanner.jsx
+++ b/src/PwaUpdateBanner.jsx
@@ -1,0 +1,109 @@
+import React, { useEffect, useState } from 'react';
+import PropTypes from 'prop-types';
+import { Button } from 'antd';
+import { HiOutlineXMark } from 'react-icons/hi2';
+
+import { IS_PROD } from './config/constants.js';
+import { applyPendingUpdate, getPendingUpdate, subscribeToPwaUpdate } from './pwaUpdate.js';
+
+import './PwaUpdateBanner.css';
+
+const isPwaBannerPreview =
+  !IS_PROD && new URLSearchParams(window.location.search).has('pwa-banner');
+
+const TRANSITION_MS = 750;
+
+function hasUpdateToShow() {
+  return isPwaBannerPreview || Boolean(getPendingUpdate());
+}
+
+export default function PwaUpdateBanner({ isDarkMode }) {
+  const [visible, setVisible] = useState(() => hasUpdateToShow());
+  const [dismissed, setDismissed] = useState(false);
+  const [mounted, setMounted] = useState(() => hasUpdateToShow());
+  const [active, setActive] = useState(false);
+
+  const shouldShow = visible && !dismissed && hasUpdateToShow();
+
+  useEffect(() => {
+    return subscribeToPwaUpdate(() => {
+      if (getPendingUpdate()) {
+        setDismissed(false);
+        setVisible(true);
+      }
+    });
+  }, []);
+
+  useEffect(() => {
+    if (shouldShow) {
+      setMounted(true);
+      const frame = requestAnimationFrame(() => {
+        requestAnimationFrame(() => setActive(true));
+      });
+      return () => cancelAnimationFrame(frame);
+    }
+
+    setActive(false);
+    return undefined;
+  }, [shouldShow]);
+
+  useEffect(() => {
+    if (!shouldShow && mounted && !active) {
+      const timer = window.setTimeout(() => setMounted(false), TRANSITION_MS);
+      return () => window.clearTimeout(timer);
+    }
+    return undefined;
+  }, [shouldShow, mounted, active]);
+
+  if (!mounted) {
+    return null;
+  }
+
+  const handleDismiss = () => {
+    setDismissed(true);
+  };
+
+  const handleApply = () => {
+    if (isPwaBannerPreview) {
+      window.location.reload();
+      return;
+    }
+    applyPendingUpdate();
+  };
+
+  return (
+    <div
+      className={[
+        'pwa-update-banner fixed bottom-2 left-2 right-2 z-[1000] flex min-h-12 items-center gap-2 rounded-lg border px-4 py-3 shadow-md sm:gap-3',
+        active ? 'pwa-update-banner--visible' : '',
+        isDarkMode ? 'pwa-update-banner--dark' : 'pwa-update-banner--light',
+      ].join(' ')}
+      role="status"
+      aria-live="polite"
+    >
+      <span
+        className={[
+          'pwa-update-banner__label min-w-0 flex-1 truncate text-sm',
+          isDarkMode ? 'pwa-update-banner__label--dark' : 'pwa-update-banner__label--light',
+        ].join(' ')}
+      >
+        Tem nova versão do app!
+      </span>
+      <Button type="primary" size="small" onClick={handleApply}>
+        Atualizar
+      </Button>
+      <Button
+        type="text"
+        size="small"
+        className="pwa-update-banner__close !min-w-0 !px-2"
+        onClick={handleDismiss}
+        aria-label="Fechar"
+        icon={<HiOutlineXMark className="text-lg opacity-70" aria-hidden />}
+      />
+    </div>
+  );
+}
+
+PwaUpdateBanner.propTypes = {
+  isDarkMode: PropTypes.bool.isRequired,
+};

--- a/src/TopBar.js
+++ b/src/TopBar.js
@@ -20,7 +20,7 @@ import { useNavigate } from 'react-router-dom';
 
 import { timeSince, getOsmUrl } from './utils/utils.js';
 
-import { TOPBAR_HEIGHT, IS_MOBILE, IS_PROD } from './config/constants.js';
+import { TOPBAR_HEIGHT, IS_MOBILE, IS_PROD, ENABLE_COMMENTS } from './config/constants.js';
 
 import EditModal from './EditModal.js';
 import Logo from './components/Logo';
@@ -130,11 +130,15 @@ function TopBar(props) {
 
   const collaborateMenu = {
     items: [
-      {
-        key: 'comment',
-        icon: <IconComment />,
-        label: 'Adicionar comentário',
-      },
+      ...(ENABLE_COMMENTS
+        ? [
+            {
+              key: 'comment',
+              icon: <IconComment />,
+              label: 'Adicionar comentário',
+            },
+          ]
+        : []),
       {
         key: 'edit',
         icon: <IconEdit />,

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -103,7 +103,7 @@ export const ENABLE_AUTO_AREA_CHANGE_ON_POINT = true;
 // they open it. Mobile-only by default; flip to `true` to also enable on
 // desktop (will require a one-time permission prompt for new users).
 export const ENABLE_AUTOFILL_ORIGIN_ON_PANEL_OPEN = IS_MOBILE;
-export const ENABLE_COMMENTS = true;
+export const ENABLE_COMMENTS = !IS_MOBILE;
 export const ENABLE_BOUNDARY_LAYER = false;
 export const ENABLE_SATELLITE_TOGGLE = false;
 

--- a/src/config/design-tokens.js
+++ b/src/config/design-tokens.js
@@ -82,7 +82,7 @@ export const typography = {
 /** Motion/duration for transitions (ms). Use with prefers-reduced-motion. */
 export const motion = {
   durationFast: 150,
-  durationNormal: 300,
+  durationNormal: 200,
   durationSlow: 500,
 };
 

--- a/src/features/directions/components/LocationSearchInput.js
+++ b/src/features/directions/components/LocationSearchInput.js
@@ -112,10 +112,9 @@ export default function LocationSearchInput({ inputType, parentComponent, classN
   const showClear = Boolean(searchValue) || hasPoint;
   const suggestions = state[`${inputType}Suggestions`];
   const query = (searchValue || '').trim();
+  const isFocused = state.focusedInput === inputType;
   const showLocalDropdown =
-    state.focusedInput === inputType &&
-    query.length < PLACES_AUTOCOMPLETE_MIN_QUERY_LENGTH &&
-    suggestions.length > 0;
+    isFocused && query.length < PLACES_AUTOCOMPLETE_MIN_QUERY_LENGTH && suggestions.length > 0;
   const showSuffix = showClear || isGeolocating;
 
   const inputSuffix = showSuffix ? (
@@ -154,12 +153,12 @@ export default function LocationSearchInput({ inputType, parentComponent, classN
       onSearch={(value) => handlers.handleSearch(value, inputType)}
       options={buildAutocompleteOptions(suggestions)}
       onSelect={(value, option) => handlers.handleSelect(option.suggestion, inputType)}
-      open={showLocalDropdown ? true : undefined}
+      open={showLocalDropdown ? true : isFocused ? undefined : false}
       className={className}
     >
       <Input
         placeholder={
-          state.focusedInput === inputType
+          isFocused
             ? ENABLE_MAP_CLICK_TO_SET_POINTS
               ? 'Digite ou clique no mapa'
               : 'Comece a digitar para buscar'

--- a/src/features/map/mapCamera.js
+++ b/src/features/map/mapCamera.js
@@ -1,0 +1,30 @@
+/**
+ * Central camera helpers for Mapbox GL.
+ *
+ * Routine moves use `maxDuration` so Mapbox snaps on long flights instead of
+ * swooping across the screen. Cinematic moves (e.g. `?flyto=` URL param) are uncapped.
+ *
+ * Do not pass `duration` to `flyMapTo` — a fixed duration bypasses the snap behavior.
+ */
+
+export const ROUTINE_FLY_MAX_DURATION_MS = 3000;
+
+/** City picker, search, geocoder — snap when the computed flight would exceed the cap. */
+export function flyMapTo(map, options = {}) {
+  if (!map) return;
+  const { duration: _duration, speed: _speed, minZoom: _minZoom, ...rest } = options;
+  map.flyTo({
+    speed: 1.5,
+    ...rest,
+    maxDuration: ROUTINE_FLY_MAX_DURATION_MS,
+  });
+}
+
+/** Intentional showcase animations — no duration cap. */
+export function flyMapToCinematic(map, options = {}) {
+  if (!map) return;
+  map.flyTo({
+    ...options,
+    essential: true,
+  });
+}

--- a/src/googlePlacesClient.js
+++ b/src/googlePlacesClient.js
@@ -3,12 +3,57 @@ import { GOOGLE_PLACES_API_KEY, GOOGLE_PLACES_DEFAULT_REGION } from './config/co
 
 let googlePlacesGeocoder = null;
 let geocoderInitialized = false;
+let googlePlacesInitError = null;
+let googleMapsAuthFailureHookInstalled = false;
+
+function installGoogleMapsAuthFailureHook() {
+  if (typeof window === 'undefined' || googleMapsAuthFailureHookInstalled) return;
+  googleMapsAuthFailureHookInstalled = true;
+  const previous = window.gm_authFailure;
+  window.gm_authFailure = () => {
+    googlePlacesInitError = Object.assign(new Error('Google Maps authentication failed'), {
+      code: 'AUTH_FAILURE',
+    });
+    geocoderInitialized = false;
+    if (typeof previous === 'function') previous();
+  };
+}
+
+/** Short PT message for UI — distinguishes load failure vs API not responding. */
+export function getPlacesSearchUserMessage(error) {
+  const code = error?.code || '';
+  if (
+    code === 'SCRIPT_LOAD_FAILED' ||
+    code === 'NOT_LOADED' ||
+    code === 'MISSING_API_KEY' ||
+    code === 'AUTH_FAILURE' ||
+    code === 'PLACES_UNAVAILABLE' ||
+    code === 'NOT_INITIALIZED' ||
+    code === 'SSR'
+  ) {
+    return 'Google Maps não carregou.';
+  }
+  if (code) {
+    return `Busca sem resposta do Google (${code}).`;
+  }
+  return 'Não foi possível buscar lugares.';
+}
 
 export function getGooglePlacesGeocoder() {
   return googlePlacesGeocoder;
 }
 
+export function getGooglePlacesInitError() {
+  return googlePlacesInitError;
+}
+
 export async function ensureGooglePlacesReady() {
+  installGoogleMapsAuthFailureHook();
+
+  if (googlePlacesInitError?.code === 'AUTH_FAILURE') {
+    throw googlePlacesInitError;
+  }
+
   if (!geocoderInitialized) {
     try {
       googlePlacesGeocoder = new GooglePlacesGeocoder({
@@ -18,8 +63,11 @@ export async function ensureGooglePlacesReady() {
       });
       await googlePlacesGeocoder.loadGoogleMapsAPI();
       geocoderInitialized = true;
+      googlePlacesInitError = null;
     } catch (error) {
+      googlePlacesInitError = error;
       console.error('Failed to initialize Google Places Geocoder:', error);
+      throw error;
     }
   }
   return googlePlacesGeocoder;

--- a/src/index.js
+++ b/src/index.js
@@ -6,6 +6,7 @@ import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import { getCssCustomProperties } from './config/design-tokens.js';
 import { IS_PROD } from './config/constants.js';
 import { PRIVACY_POLICY_PATH } from './config/routes.js';
+import { setPendingUpdate, shouldReloadForSwUpdate } from './pwaUpdate.js';
 import { SpeedInsights } from '@vercel/speed-insights/react';
 
 // Self-hosted fonts (non-blocking: loaded with the JS entry, not render-blocking <link> in HTML).
@@ -101,7 +102,7 @@ root.render(
 );
 
 // --- Service Worker update lifecycle ---
-// On update, activate the new SW immediately; controllerchange handler reloads once.
+// Show PwaUpdateBanner when an update is waiting; reload only after the user accepts.
 let hasReloadedForSwUpdate = false;
 if ('serviceWorker' in navigator) {
   const hadControllerOnLoad = Boolean(navigator.serviceWorker.controller);
@@ -109,6 +110,7 @@ if ('serviceWorker' in navigator) {
   navigator.serviceWorker.addEventListener('controllerchange', () => {
     if (hasReloadedForSwUpdate) return;
     if (!hadControllerOnLoad) return;
+    if (!shouldReloadForSwUpdate()) return;
     hasReloadedForSwUpdate = true;
     window.location.reload();
   });
@@ -142,9 +144,6 @@ window.addEventListener('unhandledrejection', (event) => {
 // Register service worker (production only).
 serviceWorkerRegistration.register({
   onUpdate: (registration) => {
-    const waiting = registration?.waiting;
-    if (waiting) {
-      waiting.postMessage({ type: 'SKIP_WAITING' });
-    }
+    setPendingUpdate(registration);
   },
 });

--- a/src/pwaUpdate.js
+++ b/src/pwaUpdate.js
@@ -29,7 +29,10 @@ export function subscribeToPwaUpdate(listener) {
 
 export function applyPendingUpdate() {
   const waiting = pendingRegistration?.waiting;
-  if (!waiting) return;
+  if (!waiting) {
+    window.location.reload();
+    return;
+  }
   userRequestedReload = true;
   waiting.postMessage({ type: 'SKIP_WAITING' });
 }

--- a/src/pwaUpdate.js
+++ b/src/pwaUpdate.js
@@ -1,0 +1,39 @@
+/** Pending service worker waiting to activate after a deploy. */
+let pendingRegistration = null;
+
+/** True after the user chooses to reload for an update (not on dismiss). */
+let userRequestedReload = false;
+
+const listeners = new Set();
+
+function notifyListeners() {
+  listeners.forEach((listener) => listener());
+}
+
+/** Called from index.js when a new service worker is installed and waiting. */
+export function setPendingUpdate(registration) {
+  const waiting = registration?.waiting;
+  if (!waiting) return;
+  pendingRegistration = registration;
+  notifyListeners();
+}
+
+export function getPendingUpdate() {
+  return pendingRegistration;
+}
+
+export function subscribeToPwaUpdate(listener) {
+  listeners.add(listener);
+  return () => listeners.delete(listener);
+}
+
+export function applyPendingUpdate() {
+  const waiting = pendingRegistration?.waiting;
+  if (!waiting) return;
+  userRequestedReload = true;
+  waiting.postMessage({ type: 'SKIP_WAITING' });
+}
+
+export function shouldReloadForSwUpdate() {
+  return userRequestedReload;
+}

--- a/src/styles/App.less
+++ b/src/styles/App.less
@@ -342,6 +342,7 @@ a {
 // Mobile: opaque panels without blur (backdrop-filter is costly on phones).
 // Desktop (≥480px): original translucent glass with blur.
 .glass-bg {
+  --glass-bg-opacity: 0.95;
   // no blur on mobile
 }
 
@@ -356,7 +357,6 @@ body.theme-dark .cm-favorite-heart {
 
 .theme-light {
   .glass-bg {
-    --glass-bg-opacity: 0.95;
     background: rgba(245, 245, 245, var(--glass-bg-opacity));
     border: 1px solid rgba(255, 255, 255, 0.35);
   }
@@ -364,7 +364,6 @@ body.theme-dark .cm-favorite-heart {
 
 .theme-dark {
   .glass-bg {
-    --glass-bg-opacity: 0.8;
     background: rgba(23, 23, 23, var(--glass-bg-opacity));
     border: 1px solid rgba(255, 255, 255, 0.1);
   }


### PR DESCRIPTION
## Summary

A bunch of product UX polish that piled up together: snappier city jumps, a less annoying city picker animation, routes panel improvements, a proper PWA update banner, better Places error handling, and some mobile cost/legibility fixes.

### Map camera
- New shared `flyMapTo` / `flyMapToCinematic` helpers.
- Everyday flights (city switch, search, geocoder…) now use `maxDuration`, so long jumps snap instead of spending several seconds swooping across the map.
- Intentional showcase flights (`?flyto=`) stay uncapped.

### City picker
- Stagger animation only on the first open per session. Nice the first time, not every time you reopen it.
- Places search failures show a short message instead of just looking empty.

### Directions panel
- Faster open/close; desktop gets a small slide-in + bike icon in the header.
- Places errors show up inline when search fails.

### Google Places
- Errors now have stable codes, and real API failures actually reject (instead of quietly returning nothing).
- Short PT messages for the UI (“Google Maps não carregou.” / “Busca sem resposta…”), including auth/load failures.

### PWA updates
- Stop auto-activating + reloading when a new service worker is waiting.
- Show a banner (“Tem nova versão do app!”) and only reload after the user taps Atualizar (or dismisses).
- If the waiting worker is already gone, Atualizar still reloads so it doesn’t dead-end.
- Dev preview with `?pwa-banner`.

### Mobile
- Skip Mapbox reverse-geocoding on mobile (pan/zoom and initial load). We never show a live city label there anyway, so those calls were just cost.
- Disable comments on mobile for now (`ENABLE_COMMENTS = !IS_MOBILE`), including the TopBar entry, popup “Comentar”, legend blurb, and the map click handler.

### Visual
- Glass backgrounds a bit more matte / less see-through on mobile.
- Popups more opaque in light and dark for contrast.
- Default motion duration 300 → 200ms.

### Smaller fixes
- City picker doesn’t stay mounted when closed; memoized so map-center churn doesn’t constantly re-render it.
- Don’t memoize a stale map viewport for the picker; read the live viewport when rendering.
- On mobile, hide TopBar/LayersBar with CSS while the routes sheet is open instead of unmounting them (cheaper).
- Keep directions-panel open state off React state so opening it doesn’t re-render the whole app.
- Fix focus/blur quirks between from/to inputs and stuck autocomplete dropdowns.
- Clearing an input brings favorites back and keeps focus.
- Catch Places init failure on boot so a bad Maps load doesn’t become an unhandled rejection.