### PR TITLE
PMTiles build and S3 sync automation

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,19 @@
+# Map & routing (client-side — restrict by domain in each provider's console)
+REACT_APP_MAPBOX_ACCESS_TOKEN=
+REACT_APP_OPENROUTESERVICE_API_KEY=
+REACT_APP_GRAPHHOPPER_API_KEY=
+REACT_APP_GOOGLE_PLACES_API_KEY=
+
+# PMTiles served to the web app (public read URL)
+REACT_APP_PMTILES_URL=https://ciclomapa.s3.us-east-1.amazonaws.com/pmtiles/
+REACT_APP_PMTILES_FILENAME=la_es_pt.pmtiles
+
+# AWS — used by scripts/sync-pmtiles-to-s3.js (not bundled into the React app)
+AWS_ACCESS_KEY_ID=
+AWS_SECRET_ACCESS_KEY=
+AWS_REGION=us-east-1
+S3_BUCKET_NAME=ciclomapa
+S3_PMTILES_PREFIX=pmtiles/
+
+# Overpass etiquette (optional; recommended for automated builds)
+CICLOMAPA_FROM=you@example.com

--- a/.github/workflows/pmtiles.yml
+++ b/.github/workflows/pmtiles.yml
@@ -29,6 +29,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - name: Setup Node
         uses: actions/setup-node@v4
@@ -56,10 +58,11 @@ jobs:
           S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME || 'ciclomapa' }}
           S3_PMTILES_PREFIX: pmtiles/
           CICLOMAPA_FROM: ${{ secrets.CICLOMAPA_FROM }}
+          PMTILES_BUILD: ${{ inputs.build }}
         run: |
           ARGS=()
-          if [ "${{ inputs.build }}" != "all" ] && [ -n "${{ inputs.build }}" ]; then
-            ARGS+=(--build "${{ inputs.build }}")
+          if [ "$PMTILES_BUILD" != "all" ] && [ -n "$PMTILES_BUILD" ]; then
+            ARGS+=(--build "$PMTILES_BUILD")
           fi
           if [ "${{ inputs.skip_geojson }}" = "true" ]; then
             ARGS+=(--skip-geojson)

--- a/.github/workflows/pmtiles.yml
+++ b/.github/workflows/pmtiles.yml
@@ -11,10 +11,6 @@ on:
         description: 'Reuse existing GeoJSON in the runner work dir when present'
         type: boolean
         default: false
-      upload_only:
-        description: 'Skip generation and only upload existing artifacts'
-        type: boolean
-        default: false
 
 # europe.pmtiles can take a long time; avoid overlapping runs.
 concurrency:
@@ -66,9 +62,6 @@ jobs:
           fi
           if [ "${{ inputs.skip_geojson }}" = "true" ]; then
             ARGS+=(--skip-geojson)
-          fi
-          if [ "${{ inputs.upload_only }}" = "true" ]; then
-            ARGS+=(--upload-only)
           fi
           node scripts/sync-pmtiles-to-s3.js "${ARGS[@]}"
 

--- a/.github/workflows/pmtiles.yml
+++ b/.github/workflows/pmtiles.yml
@@ -1,0 +1,78 @@
+name: PMtiles build & upload
+
+on:
+  workflow_dispatch:
+    inputs:
+      build:
+        description: "Build id(s) from scripts/pmtiles-builds.json (comma-separated, or 'all')"
+        required: false
+        default: 'all'
+      skip_geojson:
+        description: 'Reuse existing GeoJSON in the runner work dir when present'
+        type: boolean
+        default: false
+      upload_only:
+        description: 'Skip generation and only upload existing artifacts'
+        type: boolean
+        default: false
+
+# europe.pmtiles can take a long time; avoid overlapping runs.
+concurrency:
+  group: pmtiles-build
+  cancel-in-progress: false
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    timeout-minutes: 360
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: yarn
+
+      - name: Install Node dependencies
+        run: yarn install --frozen-lockfile
+
+      - name: Install tippecanoe
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y build-essential libsqlite3-dev zlib1g-dev
+          git clone --depth 1 https://github.com/felt/tippecanoe.git /tmp/tippecanoe
+          make -C /tmp/tippecanoe -j"$(nproc)"
+          sudo make -C /tmp/tippecanoe install
+          tippecanoe --version
+
+      - name: Build and upload PMtiles
+        env:
+          AWS_ACCESS_KEY_ID: ${{ secrets.AWS_ACCESS_KEY_ID }}
+          AWS_SECRET_ACCESS_KEY: ${{ secrets.AWS_SECRET_ACCESS_KEY }}
+          AWS_REGION: ${{ secrets.AWS_REGION || 'us-east-1' }}
+          S3_BUCKET_NAME: ${{ secrets.S3_BUCKET_NAME || 'ciclomapa' }}
+          S3_PMTILES_PREFIX: pmtiles/
+          CICLOMAPA_FROM: ${{ secrets.CICLOMAPA_FROM }}
+        run: |
+          ARGS=()
+          if [ "${{ inputs.build }}" != "all" ] && [ -n "${{ inputs.build }}" ]; then
+            ARGS+=(--build "${{ inputs.build }}")
+          fi
+          if [ "${{ inputs.skip_geojson }}" = "true" ]; then
+            ARGS+=(--skip-geojson)
+          fi
+          if [ "${{ inputs.upload_only }}" = "true" ]; then
+            ARGS+=(--upload-only)
+          fi
+          node scripts/sync-pmtiles-to-s3.js "${ARGS[@]}"
+
+      - name: Upload change reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: pmtiles-reports
+          path: .pmtiles-work/reports/
+          if-no-files-found: ignore

--- a/.gitignore
+++ b/.gitignore
@@ -19,6 +19,7 @@ npm-shrinkwrap.json
 # CicloMapa-specific
 *.geojson
 *.pmtiles
+.pmtiles-work/
 test-results/
 playwright-report/
 blob-report/

--- a/README.md
+++ b/README.md
@@ -42,6 +42,30 @@ Create a `.env` file in the project root (or set these in your environment) for 
 - `REACT_APP_MAPBOX_ACCESS_TOKEN` — Mapbox map tiles and geocoding
 - `REACT_APP_OPENROUTESERVICE_API_KEY` — Route calculations (OpenRouteService)
 - `REACT_APP_GOOGLE_PLACES_API_KEY` — Place autocomplete in the directions panel (optional)
+- `REACT_APP_PMTILES_URL` / `REACT_APP_PMTILES_FILENAME` — Vector tile archive served from S3 (see `.env.example`)
+
+### PMtiles data pipeline
+
+Generation already lives in `scripts/`:
+
+1. **`scripts/overpass-to-geojson.js`** — fetch one area from Overpass → GeoJSON (`yarn overpass -- --area "Brazil"`)
+2. **`scripts/generate-pmtiles.js`** — combine multiple areas into one `.pmtiles` via tippecanoe (`yarn generate-pmtiles -- --areas "Brazil" --output br.pmtiles`). By default excludes **Baixa velocidade**, **Trilha**, and **Proibido** (same as the app's non-PMTiles layers).
+
+To **batch the main regional builds and upload to S3**, use the thin wrapper on top of those scripts:
+
+```bash
+yarn pmtiles:list              # show regional builds (scripts/pmtiles-builds.json)
+yarn pmtiles:sync:dry-run      # preview generate + upload steps
+yarn pmtiles:sync --build br   # runs generate-pmtiles for Brazil, then uploads to S3
+```
+
+Or generate locally without S3:
+
+```bash
+yarn generate-pmtiles -- --areas "Latin America,es_pt" --output la_es_pt.pmtiles
+```
+
+For S3 upload from CI, set AWS secrets and run `.github/workflows/pmtiles.yml`. See `.env.example` for `AWS_*` and optional `CICLOMAPA_FROM`. Each sync run prints a before/after report (S3 vs new build) and saves JSON under `.pmtiles-work/reports/`.
 
 To clone the repository and install everything:
 

--- a/package.json
+++ b/package.json
@@ -57,6 +57,10 @@
     "deploy": "gh-pages -d build",
     "dev:vercel": "vercel dev",
     "overpass": "node scripts/overpass-to-geojson.js",
+    "generate-pmtiles": "node scripts/generate-pmtiles.js",
+    "pmtiles:list": "node scripts/sync-pmtiles-to-s3.js --list-builds",
+    "pmtiles:sync": "node scripts/sync-pmtiles-to-s3.js",
+    "pmtiles:sync:dry-run": "node scripts/sync-pmtiles-to-s3.js --dry-run",
     "generate-pwa-icons": "node scripts/generate-pwa-icons.js",
     "prepare": "husky || true"
   },
@@ -93,6 +97,7 @@
     "husky": "^9.1.7",
     "jest-axe": "^10.0.0",
     "lint-staged": "^15.2.10",
+    "pmtiles": "^3.2.1",
     "postcss": "8.5.18",
     "prettier": "^3.4.2",
     "sharp": "^0.35.0",

--- a/scripts/generate-pmtiles.js
+++ b/scripts/generate-pmtiles.js
@@ -38,6 +38,28 @@ const AREA_ALIASES = {
     'Uruguay',
     'Venezuela',
   ],
+  'latin america': [
+    'Argentina',
+    'Bolivia',
+    'Chile',
+    'Colombia',
+    'Ecuador',
+    'Guyana',
+    'Mexico',
+    'Paraguay',
+    'Peru',
+    'Suriname',
+    'Uruguay',
+    'Venezuela',
+    'Belize',
+    'Costa Rica',
+    'El Salvador',
+    'Guatemala',
+    'Honduras',
+    'Nicaragua',
+    'Panama',
+  ],
+  es_pt: ['Spain', 'Portugal'],
   'iberian peninsula': ['Spain', 'Portugal', 'Andorra', 'Gibraltar'],
   europe: [
     'Austria',
@@ -58,6 +80,9 @@ const AREA_ALIASES = {
   ],
   uk: ['United Kingdom'],
 };
+
+// PMtiles intentionally omit low-priority / routing-only layers (see OSMController.js).
+const DEFAULT_PMTILES_EXCLUDE_LAYERS = ['Baixa velocidade', 'Trilha', 'Proibido'];
 
 // Path to the overpass-to-geojson script
 const OVERPASS_SCRIPT = path.join(__dirname, 'overpass-to-geojson.js');
@@ -136,8 +161,8 @@ Options:
   --output <file>     Output PMtiles file path (default: all.pmtiles)
   --areas <list>      Comma-separated list of areas (alternative to positional args)
   --endpoint <url>    Overpass API endpoint (passed to overpass-to-geojson.js)
-  --include-layers    Comma-separated list of layer names to include
-  --exclude-layers    Comma-separated list of layer names to exclude
+  --include-layers    Comma-separated list of layer names to include (disables default exclusions)
+  --exclude-layers    Comma-separated list of extra layer names to exclude (defaults always exclude Baixa velocidade, Trilha, Proibido)
   --include-poi       Include POI (Point of Interest) layers
   --skip-geojson      Skip GeoJSON generation if files already exist
   --skip-existing-geojsons   Alias for --skip-geojson
@@ -151,6 +176,8 @@ Examples:
 
 Aliases:
   "South America" -> Argentina, Bolivia, Brazil, Chile, Colombia, Ecuador, Guyana, Paraguay, Peru, Suriname, Uruguay, Venezuela
+  "Latin America" -> South/Central America + Mexico, excluding Brazil (see AREA_ALIASES in generate-pmtiles.js)
+  "es_pt" -> Spain, Portugal
   "Iberian Peninsula" -> Spain, Portugal, Andorra, Gibraltar
   "europe" -> Austria, Belgium, Denmark, Finland, France, Germany, Ireland, Italy, Luxembourg, Netherlands, Norway, Portugal, Spain, Sweden, Switzerland
   "uk" -> United Kingdom
@@ -163,6 +190,13 @@ Aliases:
   }
 
   config.areas = expandAreaAliases(config.areas);
+
+  if (!config.includeLayers) {
+    config.excludeLayers = [
+      ...new Set([...DEFAULT_PMTILES_EXCLUDE_LAYERS, ...(config.excludeLayers || [])]),
+    ];
+  }
+
   return config;
 }
 
@@ -329,7 +363,7 @@ async function main() {
     console.log(`   Output: ${config.output}`);
     console.log(`   Skip GeoJSON: ${config.skipGeoJSON ? 'YES' : 'NO'}`);
     console.log(
-      `   Include layers: ${config.includeLayers ? config.includeLayers.join(', ') : 'ALL'}`
+      `   Include layers: ${config.includeLayers ? config.includeLayers.join(', ') : 'default (cycle infra)'}`
     );
     console.log(
       `   Exclude layers: ${config.excludeLayers ? config.excludeLayers.join(', ') : 'NONE'}`
@@ -438,4 +472,10 @@ if (require.main === module) {
   main();
 }
 
-module.exports = { main, generateGeoJSONForArea, generatePMtiles };
+module.exports = {
+  main,
+  generateGeoJSONForArea,
+  generatePMtiles,
+  expandAreaAliases,
+  getExpectedGeoJSONFilename,
+};

--- a/scripts/pmtiles-builds.json
+++ b/scripts/pmtiles-builds.json
@@ -50,6 +50,13 @@
       "description": "Barcelona city — cycle layers + POIs"
     },
     {
+      "id": "spain",
+      "output": "spain.pmtiles",
+      "areas": ["Spain"],
+      "includePoi": false,
+      "description": "Spain"
+    },
+    {
       "id": "spain-poi",
       "output": "spain-poi.pmtiles",
       "areas": ["Spain"],

--- a/scripts/pmtiles-builds.json
+++ b/scripts/pmtiles-builds.json
@@ -7,10 +7,10 @@
       "description": "Production — Brazil only"
     },
     {
-      "id": "la",
+      "id": "la--except-br",
       "output": "la.pmtiles",
       "areas": ["Latin America"],
-      "description": "Latin America only (excludes Brazil)"
+      "description": "Latin America except Brazil)"
     },
     {
       "id": "la_es_pt",
@@ -47,21 +47,21 @@
       "output": "barcelona-poi.pmtiles",
       "areas": ["Barcelona"],
       "includePoi": true,
-      "description": "Barcelona city — cycle layers + POIs (non-standard)"
+      "description": "Barcelona city — cycle layers + POIs"
     },
     {
       "id": "spain-poi",
       "output": "spain-poi.pmtiles",
       "areas": ["Spain"],
       "includePoi": true,
-      "description": "Spain — cycle layers + POIs (non-standard)"
+      "description": "Spain — cycle layers + POIs"
     },
     {
       "id": "brazil-poi",
       "output": "brazil-poi.pmtiles",
       "areas": ["Brazil"],
       "includePoi": true,
-      "description": "Brazil — cycle layers + POIs (non-standard)"
+      "description": "Brazil — cycle layers + POIs"
     }
   ]
 }

--- a/scripts/pmtiles-builds.json
+++ b/scripts/pmtiles-builds.json
@@ -1,0 +1,67 @@
+{
+  "builds": [
+    {
+      "id": "br",
+      "output": "br.pmtiles",
+      "areas": ["Brazil"],
+      "description": "Production — Brazil only"
+    },
+    {
+      "id": "la",
+      "output": "la.pmtiles",
+      "areas": ["Latin America"],
+      "description": "Latin America only (excludes Brazil)"
+    },
+    {
+      "id": "la_es_pt",
+      "output": "la_es_pt.pmtiles",
+      "areas": ["Latin America", "es_pt"],
+      "description": "Preview default — Latin America + Spain + Portugal"
+    },
+    {
+      "id": "br_es_pt",
+      "output": "br_es_pt.pmtiles",
+      "areas": ["Brazil", "es_pt"],
+      "description": "Brazil + Spain + Portugal"
+    },
+    {
+      "id": "de",
+      "output": "de.pmtiles",
+      "areas": ["Germany"],
+      "description": "Germany"
+    },
+    {
+      "id": "europe",
+      "output": "europe.pmtiles",
+      "areas": ["europe"],
+      "description": "Western/Northern Europe bundle (see AREA_ALIASES in generate-pmtiles.js)"
+    },
+    {
+      "id": "colombia",
+      "output": "colombia.pmtiles",
+      "areas": ["Colombia"],
+      "description": "Test build — Colombia"
+    },
+    {
+      "id": "barcelona-poi",
+      "output": "barcelona-poi.pmtiles",
+      "areas": ["Barcelona"],
+      "includePoi": true,
+      "description": "Barcelona city — cycle layers + POIs (non-standard)"
+    },
+    {
+      "id": "spain-poi",
+      "output": "spain-poi.pmtiles",
+      "areas": ["Spain"],
+      "includePoi": true,
+      "description": "Spain — cycle layers + POIs (non-standard)"
+    },
+    {
+      "id": "brazil-poi",
+      "output": "brazil-poi.pmtiles",
+      "areas": ["Brazil"],
+      "includePoi": true,
+      "description": "Brazil — cycle layers + POIs (non-standard)"
+    }
+  ]
+}

--- a/scripts/sync-pmtiles-to-s3.js
+++ b/scripts/sync-pmtiles-to-s3.js
@@ -433,7 +433,6 @@ async function uploadToS3(localPath, outputFilename, { dryRun }) {
       Bucket: bucket,
       Key: key,
       Body: fs.createReadStream(localPath),
-      ACL: 'public-read',
       ContentType: 'application/vnd.pmtiles',
       CacheControl: 'public, max-age=3600',
     })

--- a/scripts/sync-pmtiles-to-s3.js
+++ b/scripts/sync-pmtiles-to-s3.js
@@ -301,7 +301,12 @@ function countFeatureMarkers(filePath) {
   });
 }
 
+function workDirForBuild(build) {
+  return path.join(WORK_DIR, build.id);
+}
+
 async function countGeoJsonFeaturesForBuild(build) {
+  const buildDir = workDirForBuild(build);
   const expectedFiles = new Set(
     expandAreaAliases(build.areas).map((area) => getExpectedGeoJSONFilename(area))
   );
@@ -309,7 +314,7 @@ async function countGeoJsonFeaturesForBuild(build) {
   const files = [];
 
   for (const filename of expectedFiles) {
-    const filePath = path.join(WORK_DIR, filename);
+    const filePath = path.join(buildDir, filename);
     const exists = await fsp
       .access(filePath)
       .then(() => true)
@@ -472,14 +477,16 @@ async function runGeneratePMtiles(build, localOutputPath, options) {
   if (options.cleanup) args.push('--cleanup');
   if (build.includePoi) args.push('--include-poi');
 
-  await fsp.mkdir(WORK_DIR, { recursive: true });
+  const buildDir = workDirForBuild(build);
+  await fsp.mkdir(buildDir, { recursive: true });
 
   return new Promise((resolve, reject) => {
     console.log(`   Running: node scripts/generate-pmtiles.js ${args.join(' ')}`);
+    console.log(`   GeoJSON work dir: ${buildDir}`);
 
     const child = spawn('node', [GENERATE_SCRIPT, ...args], {
       stdio: 'inherit',
-      cwd: WORK_DIR,
+      cwd: buildDir,
     });
 
     child.on('close', (code) => {

--- a/scripts/sync-pmtiles-to-s3.js
+++ b/scripts/sync-pmtiles-to-s3.js
@@ -277,6 +277,30 @@ async function inspectLocalBuild(localPath) {
   };
 }
 
+// Continent-size GeoJSON files can be multi-gigabyte, well past what JSON.parse
+// can safely hold in memory. Instead of parsing, we stream the file and count
+// occurrences of the `"type":"Feature"` marker that starts every feature object.
+const FEATURE_MARKER_RE = /"type"\s*:\s*"Feature"/g;
+const FEATURE_MARKER_OVERLAP = 32; // longer than the marker, covers stray whitespace
+
+function countFeatureMarkers(filePath) {
+  return new Promise((resolve, reject) => {
+    let count = 0;
+    let tail = '';
+
+    const stream = fs.createReadStream(filePath, { encoding: 'utf8' });
+    stream.on('data', (chunk) => {
+      const combined = tail + chunk;
+      for (const match of combined.matchAll(FEATURE_MARKER_RE)) {
+        if (match.index + match[0].length > tail.length) count += 1;
+      }
+      tail = combined.slice(-FEATURE_MARKER_OVERLAP);
+    });
+    stream.on('end', () => resolve(count));
+    stream.on('error', reject);
+  });
+}
+
 async function countGeoJsonFeaturesForBuild(build) {
   const expectedFiles = new Set(
     expandAreaAliases(build.areas).map((area) => getExpectedGeoJSONFilename(area))
@@ -292,8 +316,7 @@ async function countGeoJsonFeaturesForBuild(build) {
       .catch(() => false);
     if (!exists) continue;
 
-    const geojson = JSON.parse(await fsp.readFile(filePath, 'utf8'));
-    const features = Array.isArray(geojson.features) ? geojson.features.length : 0;
+    const features = await countFeatureMarkers(filePath);
     totalFeatures += features;
     files.push({ file: filename, features });
   }

--- a/scripts/sync-pmtiles-to-s3.js
+++ b/scripts/sync-pmtiles-to-s3.js
@@ -1,0 +1,599 @@
+#!/usr/bin/env node
+
+/**
+ * Upload generated PMtiles to the CicloMapa S3 bucket.
+ *
+ * Generation is handled by the existing scripts/generate-pmtiles.js pipeline
+ * (which calls scripts/overpass-to-geojson.js per area, then tippecanoe).
+ * This script only adds batch definitions (pmtiles-builds.json) and S3 upload.
+ *
+ * Usage:
+ *   node scripts/sync-pmtiles-to-s3.js [options]
+ *
+ * Options:
+ *   --build <ids>       Comma-separated build ids from pmtiles-builds.json (default: all)
+ *   --list-builds       Print configured builds and exit
+ *   --skip-geojson      Reuse existing per-area GeoJSON files when present
+ *   --skip-upload       Generate locally but do not upload to S3
+ *   --upload-only       Skip generation; upload existing local .pmtiles files
+ *   --cleanup           Remove per-area GeoJSON files after each build
+ *   --dry-run           Print actions without generating or uploading
+ *   --help, -h          Show help
+ *
+ * Before each upload, the script compares the current S3 object with the new
+ * local build (size, tile counts, zoom/bounds, GeoJSON feature totals) and
+ * writes a JSON report under .pmtiles-work/reports/.
+ *
+ * Environment (also read from .env in project root when present):
+ *   AWS_ACCESS_KEY_ID, AWS_SECRET_ACCESS_KEY, AWS_REGION (default: us-east-1)
+ *   S3_BUCKET_NAME (default: ciclomapa)
+ *   S3_PMTILES_PREFIX (default: pmtiles/)
+ *   CICLOMAPA_FROM (optional, passed to overpass-to-geojson as --from)
+ */
+
+const fs = require('fs');
+const fsp = require('fs').promises;
+const path = require('path');
+const { spawn } = require('child_process');
+
+const AWS = require('aws-sdk');
+const { PMTiles } = require('pmtiles');
+const { expandAreaAliases, getExpectedGeoJSONFilename } = require('./generate-pmtiles');
+
+const ROOT = path.join(__dirname, '..');
+const GENERATE_SCRIPT = path.join(__dirname, 'generate-pmtiles.js');
+const BUILDS_PATH = path.join(__dirname, 'pmtiles-builds.json');
+const WORK_DIR = path.join(ROOT, '.pmtiles-work');
+const REPORTS_DIR = path.join(WORK_DIR, 'reports');
+
+class NodeFileSource {
+  constructor(filePath) {
+    this.filePath = filePath;
+  }
+
+  getKey() {
+    return this.filePath;
+  }
+
+  async getBytes(offset, length) {
+    const fh = await fsp.open(this.filePath, 'r');
+    try {
+      const buf = Buffer.alloc(length);
+      const { bytesRead } = await fh.read(buf, 0, length, offset);
+      return {
+        data: buf.subarray(0, bytesRead).buffer.slice(buf.byteOffset, buf.byteOffset + bytesRead),
+      };
+    } finally {
+      await fh.close();
+    }
+  }
+}
+
+function loadDotEnv() {
+  const envPath = path.join(ROOT, '.env');
+  if (!fs.existsSync(envPath)) return;
+  const lines = fs.readFileSync(envPath, 'utf8').split('\n');
+  for (const line of lines) {
+    const trimmed = line.trim();
+    if (!trimmed || trimmed.startsWith('#')) continue;
+    const eq = trimmed.indexOf('=');
+    if (eq === -1) continue;
+    const key = trimmed.slice(0, eq).trim();
+    const value = trimmed.slice(eq + 1).trim();
+    if (process.env[key] === undefined) {
+      process.env[key] = value;
+    }
+  }
+}
+
+function parseArgs() {
+  const args = process.argv.slice(2);
+  const config = {
+    buildIds: null,
+    listBuilds: false,
+    skipGeoJSON: false,
+    skipUpload: false,
+    uploadOnly: false,
+    cleanup: false,
+    dryRun: false,
+  };
+
+  for (let i = 0; i < args.length; i++) {
+    const arg = args[i];
+    if (arg === '--build' && i + 1 < args.length) {
+      config.buildIds = args[++i]
+        .split(',')
+        .map((s) => s.trim())
+        .filter(Boolean);
+    } else if (arg === '--list-builds') {
+      config.listBuilds = true;
+    } else if (arg === '--skip-geojson') {
+      config.skipGeoJSON = true;
+    } else if (arg === '--skip-upload') {
+      config.skipUpload = true;
+    } else if (arg === '--upload-only') {
+      config.uploadOnly = true;
+    } else if (arg === '--cleanup') {
+      config.cleanup = true;
+    } else if (arg === '--dry-run') {
+      config.dryRun = true;
+    } else if (arg === '--help' || arg === '-h') {
+      console.log(fs.readFileSync(__filename, 'utf8').match(/\/\*\*([\s\S]*?)\*\//)[1]);
+      process.exit(0);
+    } else {
+      console.error(`Unknown argument: ${arg}`);
+      process.exit(1);
+    }
+  }
+
+  return config;
+}
+
+function loadBuilds() {
+  const raw = fs.readFileSync(BUILDS_PATH, 'utf8');
+  const parsed = JSON.parse(raw);
+  if (!Array.isArray(parsed.builds) || parsed.builds.length === 0) {
+    throw new Error(`No builds found in ${BUILDS_PATH}`);
+  }
+  return parsed.builds;
+}
+
+function getS3Config() {
+  return {
+    bucket: process.env.S3_BUCKET_NAME || 'ciclomapa',
+    prefix: process.env.S3_PMTILES_PREFIX || 'pmtiles/',
+    region: process.env.AWS_REGION || 'us-east-1',
+  };
+}
+
+function getS3Client() {
+  const { region } = getS3Config();
+  return new AWS.S3({
+    accessKeyId: process.env.AWS_ACCESS_KEY_ID,
+    secretAccessKey: process.env.AWS_SECRET_ACCESS_KEY,
+    region,
+    signatureVersion: 'v4',
+  });
+}
+
+function s3KeyForOutput(output, prefix) {
+  const normalizedPrefix = prefix.endsWith('/') ? prefix : `${prefix}/`;
+  return `${normalizedPrefix}${output}`;
+}
+
+async function fileSize(filePath) {
+  const stat = await fsp.stat(filePath);
+  return stat.size;
+}
+
+function formatBytes(bytes) {
+  if (bytes == null) return '—';
+  if (bytes < 1024) return `${bytes} B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)} KB`;
+  if (bytes < 1024 * 1024 * 1024) return `${(bytes / (1024 * 1024)).toFixed(1)} MB`;
+  return `${(bytes / (1024 * 1024 * 1024)).toFixed(2)} GB`;
+}
+
+function formatBounds(header) {
+  if (!header) return '—';
+  return `${header.minLon.toFixed(3)}, ${header.minLat.toFixed(3)}, ${header.maxLon.toFixed(3)}, ${header.maxLat.toFixed(3)}`;
+}
+
+function formatZoom(header) {
+  if (!header) return '—';
+  return `${header.minZoom}–${header.maxZoom}`;
+}
+
+function formatDelta(before, after, { suffix = '', percent = false } = {}) {
+  if (before == null || after == null) return '—';
+  const delta = after - before;
+  if (delta === 0) return 'no change';
+  const sign = delta > 0 ? '+' : '';
+  if (percent && before !== 0) {
+    const pct = ((delta / before) * 100).toFixed(1);
+    return `${sign}${delta}${suffix} (${sign}${pct}%)`;
+  }
+  return `${sign}${delta}${suffix}`;
+}
+
+function publicUrlForKey(key) {
+  const { bucket, region } = getS3Config();
+  return `https://${bucket}.s3.${region}.amazonaws.com/${key}`;
+}
+
+async function inspectPmtilesHeader(source) {
+  const pmtiles = new PMTiles(source);
+  const header = await pmtiles.getHeader();
+  return {
+    numTileEntries: header.numTileEntries,
+    numAddressedTiles: header.numAddressedTiles,
+    numTileContents: header.numTileContents,
+    minZoom: header.minZoom,
+    maxZoom: header.maxZoom,
+    bounds: formatBounds(header),
+    center: `${header.centerLon.toFixed(3)}, ${header.centerLat.toFixed(3)} @ z${header.centerZoom}`,
+  };
+}
+
+async function inspectRemoteBuild(outputFilename) {
+  const { bucket, prefix } = getS3Config();
+  const key = s3KeyForOutput(outputFilename, prefix);
+  const url = publicUrlForKey(key);
+
+  if (!process.env.AWS_ACCESS_KEY_ID || !process.env.AWS_SECRET_ACCESS_KEY) {
+    return { exists: false, key, url, note: 'AWS credentials not configured' };
+  }
+
+  const s3 = getS3Client();
+  try {
+    const head = await s3.headObject({ Bucket: bucket, Key: key }).promise();
+    let header = null;
+    try {
+      header = await inspectPmtilesHeader(url);
+    } catch (error) {
+      header = { error: error.message };
+    }
+
+    return {
+      exists: true,
+      key,
+      url,
+      size: head.ContentLength,
+      lastModified: head.LastModified?.toISOString() ?? null,
+      etag: head.ETag,
+      header,
+    };
+  } catch (error) {
+    if (error.code === 'NotFound' || error.statusCode === 404) {
+      return { exists: false, key, url };
+    }
+    throw error;
+  }
+}
+
+async function inspectLocalBuild(localPath) {
+  const exists = await fsp
+    .access(localPath)
+    .then(() => true)
+    .catch(() => false);
+  if (!exists) {
+    return { exists: false, path: localPath };
+  }
+
+  const stat = await fsp.stat(localPath);
+  let header = null;
+  try {
+    header = await inspectPmtilesHeader(new NodeFileSource(localPath));
+  } catch (error) {
+    header = { error: error.message };
+  }
+
+  return {
+    exists: true,
+    path: localPath,
+    size: stat.size,
+    lastModified: stat.mtime.toISOString(),
+    header,
+  };
+}
+
+async function countGeoJsonFeaturesForBuild(build) {
+  const expectedFiles = new Set(
+    expandAreaAliases(build.areas).map((area) => getExpectedGeoJSONFilename(area))
+  );
+  let totalFeatures = 0;
+  const files = [];
+
+  for (const filename of expectedFiles) {
+    const filePath = path.join(WORK_DIR, filename);
+    const exists = await fsp
+      .access(filePath)
+      .then(() => true)
+      .catch(() => false);
+    if (!exists) continue;
+
+    const geojson = JSON.parse(await fsp.readFile(filePath, 'utf8'));
+    const features = Array.isArray(geojson.features) ? geojson.features.length : 0;
+    totalFeatures += features;
+    files.push({ file: filename, features });
+  }
+
+  return { totalFeatures, files };
+}
+
+function formatTimestamp(value) {
+  if (!value) return '—';
+  return String(value)
+    .replace('T', ' ')
+    .replace(/\.\d{3}Z$/, ' UTC');
+}
+
+function printChangeReport(build, before, after, geojsonStats) {
+  console.log('');
+  console.log(`📊 Change report: ${build.output}`);
+  console.log('─'.repeat(78));
+
+  const rows = [
+    ['Status', before.exists ? 'on S3' : 'not on S3', after.exists ? 'local build' : 'missing'],
+    ['Size', formatBytes(before.size), formatBytes(after.size)],
+    [
+      'Size delta',
+      '—',
+      before.exists && after.exists ? formatDelta(before.size, after.size, { percent: true }) : '—',
+    ],
+    ['Last modified', formatTimestamp(before.lastModified), formatTimestamp(after.lastModified)],
+    ['Tile entries', before.header?.numTileEntries ?? '—', after.header?.numTileEntries ?? '—'],
+    [
+      'Tile entries delta',
+      '—',
+      before.header?.numTileEntries != null && after.header?.numTileEntries != null
+        ? formatDelta(before.header.numTileEntries, after.header.numTileEntries)
+        : '—',
+    ],
+    [
+      'Addressed tiles',
+      before.header?.numAddressedTiles ?? '—',
+      after.header?.numAddressedTiles ?? '—',
+    ],
+    ['Zoom range', formatZoom(before.header), formatZoom(after.header)],
+    [
+      'Bounds (W,S,E,N)',
+      before.header?.bounds ?? '—',
+      before.header?.bounds && after.header?.bounds && before.header.bounds === after.header.bounds
+        ? 'no change'
+        : (after.header?.bounds ?? '—'),
+    ],
+    [
+      'GeoJSON features',
+      '—',
+      geojsonStats?.totalFeatures != null ? String(geojsonStats.totalFeatures) : '—',
+    ],
+  ];
+
+  const col1 = 20;
+  const col2 = 28;
+  console.log(`${''.padEnd(col1)}${'Before (S3)'.padEnd(col2)}After (new)`);
+  for (const [label, left, right] of rows) {
+    console.log(`${label.padEnd(col1)}${String(left).padEnd(col2)}${right}`);
+  }
+
+  if (geojsonStats?.files?.length) {
+    console.log('');
+    console.log('   GeoJSON inputs:');
+    for (const { file, features } of geojsonStats.files) {
+      console.log(`   - ${file}: ${features.toLocaleString()} features`);
+    }
+  }
+
+  if (before.header?.error) {
+    console.log(`   ⚠️  Could not read remote PMtiles header: ${before.header.error}`);
+  }
+  if (after.header?.error) {
+    console.log(`   ⚠️  Could not read local PMtiles header: ${after.header.error}`);
+  }
+
+  console.log('─'.repeat(78));
+}
+
+async function writeChangeReport(build, before, after, geojsonStats) {
+  await fsp.mkdir(REPORTS_DIR, { recursive: true });
+  const stamp = new Date().toISOString().replace(/[:.]/g, '-');
+  const reportPath = path.join(REPORTS_DIR, `${build.id}-${stamp}.json`);
+  const payload = {
+    buildId: build.id,
+    output: build.output,
+    areas: build.areas,
+    generatedAt: new Date().toISOString(),
+    before,
+    after,
+    geojson: geojsonStats,
+    deltas: {
+      sizeBytes: before.size != null && after.size != null ? after.size - before.size : null,
+      tileEntries:
+        before.header?.numTileEntries != null && after.header?.numTileEntries != null
+          ? after.header.numTileEntries - before.header.numTileEntries
+          : null,
+      addressedTiles:
+        before.header?.numAddressedTiles != null && after.header?.numAddressedTiles != null
+          ? after.header.numAddressedTiles - before.header.numAddressedTiles
+          : null,
+    },
+  };
+  await fsp.writeFile(reportPath, `${JSON.stringify(payload, null, 2)}\n`);
+  console.log(`   Report saved: ${reportPath}`);
+  return reportPath;
+}
+
+async function uploadToS3(localPath, outputFilename, { dryRun }) {
+  const { bucket, prefix } = getS3Config();
+  const key = s3KeyForOutput(outputFilename, prefix);
+  const exists = await fsp
+    .access(localPath)
+    .then(() => true)
+    .catch(() => false);
+  const size = exists ? await fileSize(localPath) : 0;
+
+  if (dryRun) {
+    const sizeLabel = exists ? formatBytes(size) : 'file not generated yet';
+    console.log(`   [dry-run] Would upload ${localPath} → s3://${bucket}/${key} (${sizeLabel})`);
+    return { bucket, key, size };
+  }
+
+  if (!process.env.AWS_ACCESS_KEY_ID || !process.env.AWS_SECRET_ACCESS_KEY) {
+    throw new Error(
+      'Missing AWS credentials. Set AWS_ACCESS_KEY_ID and AWS_SECRET_ACCESS_KEY in .env or the environment.'
+    );
+  }
+
+  const s3 = getS3Client();
+  console.log(`   Uploading ${formatBytes(size)} → s3://${bucket}/${key}`);
+
+  await s3
+    .upload({
+      Bucket: bucket,
+      Key: key,
+      Body: fs.createReadStream(localPath),
+      ACL: 'public-read',
+      ContentType: 'application/vnd.pmtiles',
+      CacheControl: 'public, max-age=3600',
+    })
+    .promise();
+
+  const publicUrl = `https://${bucket}.s3.${getS3Config().region}.amazonaws.com/${key}`;
+  console.log(`   ✓ Uploaded: ${publicUrl}`);
+  return { bucket, key, size, url: publicUrl };
+}
+
+async function runGeneratePMtiles(build, localOutputPath, options) {
+  const args = ['--output', localOutputPath, '--areas', build.areas.join(',')];
+  if (options.skipGeoJSON) args.push('--skip-geojson');
+  if (options.cleanup) args.push('--cleanup');
+  if (build.includePoi) args.push('--include-poi');
+
+  await fsp.mkdir(WORK_DIR, { recursive: true });
+
+  return new Promise((resolve, reject) => {
+    console.log(`   Running: node scripts/generate-pmtiles.js ${args.join(' ')}`);
+
+    const child = spawn('node', [GENERATE_SCRIPT, ...args], {
+      stdio: 'inherit',
+      cwd: WORK_DIR,
+    });
+
+    child.on('close', (code) => {
+      if (code === 0) resolve();
+      else reject(new Error(`generate-pmtiles.js exited with code ${code} for build: ${build.id}`));
+    });
+
+    child.on('error', (error) => {
+      reject(new Error(`Failed to spawn generate-pmtiles.js: ${error.message}`));
+    });
+  });
+}
+
+async function ensureWorkDir() {
+  await fsp.mkdir(WORK_DIR, { recursive: true });
+}
+
+async function buildOne(build, options) {
+  const localOutputPath = path.join(WORK_DIR, build.output);
+
+  console.log('');
+  console.log(`▶ Build: ${build.id}`);
+  console.log(`  ${build.description || build.areas.join(', ')}`);
+  console.log(`  Output: ${build.output}`);
+
+  const before = await inspectRemoteBuild(build.output);
+
+  if (!options.uploadOnly) {
+    if (options.dryRun) {
+      console.log(
+        `   [dry-run] Would generate ${build.output} from areas: ${build.areas.join(', ')}`
+      );
+    } else {
+      await runGeneratePMtiles(build, localOutputPath, options);
+    }
+  }
+
+  const after = options.dryRun
+    ? await inspectLocalBuild(localOutputPath).catch(() => ({ exists: false }))
+    : await inspectLocalBuild(localOutputPath);
+
+  const geojsonStats =
+    options.dryRun || options.uploadOnly
+      ? null
+      : await countGeoJsonFeaturesForBuild(build).catch(() => null);
+
+  if (!options.dryRun) {
+    printChangeReport(build, before, after, geojsonStats);
+    await writeChangeReport(build, before, after, geojsonStats);
+  } else if (before.exists || after.exists) {
+    printChangeReport(build, before, after, geojsonStats);
+  }
+
+  if (options.skipUpload) {
+    console.log('   Skipping upload (--skip-upload)');
+    return { build: build.id, before, after, geojsonStats };
+  }
+
+  if (options.dryRun) {
+    return uploadToS3(localOutputPath, build.output, { dryRun: true });
+  }
+
+  if (!after.exists) {
+    throw new Error(`Expected output not found: ${localOutputPath}`);
+  }
+
+  return uploadToS3(localOutputPath, build.output, { dryRun: false });
+}
+
+async function main() {
+  loadDotEnv();
+  const options = parseArgs();
+  const builds = loadBuilds();
+
+  if (options.listBuilds) {
+    console.log('Configured PMtiles builds:\n');
+    for (const build of builds) {
+      console.log(`  ${build.id}`);
+      console.log(`    output: ${build.output}`);
+      console.log(`    areas:  ${build.areas.join(', ')}`);
+      if (build.includePoi) console.log(`    POIs:   included`);
+      if (build.description) console.log(`    note:   ${build.description}`);
+      console.log('');
+    }
+    return;
+  }
+
+  let selected = builds;
+  if (options.buildIds) {
+    const known = new Set(builds.map((b) => b.id));
+    const unknown = options.buildIds.filter((id) => !known.has(id));
+    if (unknown.length > 0) {
+      throw new Error(
+        `Unknown build id(s): ${unknown.join(', ')}. Use --list-builds to see options.`
+      );
+    }
+    selected = builds.filter((b) => options.buildIds.includes(b.id));
+  }
+
+  await ensureWorkDir();
+
+  console.log('');
+  console.log('🚀 CicloMapa PMtiles → S3');
+  console.log('─'.repeat(60));
+  console.log(`   Builds: ${selected.map((b) => b.id).join(', ')}`);
+  console.log(`   Work dir: ${WORK_DIR}`);
+  console.log(`   S3 bucket: ${getS3Config().bucket}`);
+  console.log(`   S3 prefix: ${getS3Config().prefix}`);
+  console.log(`   Upload: ${options.skipUpload ? 'NO' : 'YES'}`);
+  console.log(
+    `   Mode: ${options.uploadOnly ? 'upload-only' : options.dryRun ? 'dry-run' : 'generate+upload'}`
+  );
+  console.log('─'.repeat(60));
+
+  const results = [];
+  for (const build of selected) {
+    results.push(await buildOne(build, options));
+  }
+
+  console.log('');
+  console.log('✨ Done');
+  if (!options.skipUpload && !options.dryRun) {
+    for (const result of results) {
+      if (result?.url) console.log(`   ${result.url}`);
+    }
+  }
+  console.log('');
+}
+
+if (require.main === module) {
+  main().catch((error) => {
+    console.error('');
+    console.error('❌ Error:', error.message);
+    console.error('');
+    process.exit(1);
+  });
+}
+
+module.exports = { main, loadBuilds, uploadToS3 };

--- a/src/Map.js
+++ b/src/Map.js
@@ -7,6 +7,7 @@ import turfCircle from '@turf/circle';
 import 'mapbox-gl/dist/mapbox-gl.css';
 import { PmTilesSource } from 'mapbox-pmtiles';
 
+import { startDataLoad, finishDataLoad } from './dev/dataLoadTracker.js';
 import {
   MAPBOX_ACCESS_TOKEN,
   USE_GEOJSON_SOURCE,
@@ -1402,6 +1403,7 @@ class Map extends Component {
     }
 
     if (USE_PMTILES_SOURCE) {
+      const pmtilesLoadToken = startDataLoad('pmtiles', 'PMTiles', { file: PMTILES_FILENAME });
       try {
         const PMTILES_URL = process.env.REACT_APP_PMTILES_URL + PMTILES_FILENAME;
         console.log('Loading PMTiles from S3:', PMTILES_URL);
@@ -1426,12 +1428,24 @@ class Map extends Component {
 
         console.log('PMTiles source added successfully');
         this.pmtilesLoadedSuccessfully = true;
+        finishDataLoad('pmtiles', {
+          token: pmtilesLoadToken,
+          meta: {
+            file: PMTILES_FILENAME,
+            zoom: `${header.minZoom}-${header.maxZoom}`,
+          },
+        });
 
         // Hide geojson features from pmtiles layers
         this.hideGeoJsonFromPmtiles(this.props.data);
       } catch (error) {
         console.error('Error setting up PmTiles for cyclepaths:', error);
         this.pmtilesLoadedSuccessfully = false;
+        finishDataLoad('pmtiles', {
+          token: pmtilesLoadToken,
+          error,
+          meta: { file: PMTILES_FILENAME },
+        });
       }
     }
   }

--- a/src/Map.js
+++ b/src/Map.js
@@ -1428,6 +1428,10 @@ class Map extends Component {
 
         console.log('PMTiles source added successfully');
         this.pmtilesLoadedSuccessfully = true;
+
+        // Hide geojson features from pmtiles layers
+        this.hideGeoJsonFromPmtiles(this.props.data);
+
         finishDataLoad('pmtiles', {
           token: pmtilesLoadToken,
           meta: {
@@ -1435,9 +1439,6 @@ class Map extends Component {
             zoom: `${header.minZoom}-${header.maxZoom}`,
           },
         });
-
-        // Hide geojson features from pmtiles layers
-        this.hideGeoJsonFromPmtiles(this.props.data);
       } catch (error) {
         console.error('Error setting up PmTiles for cyclepaths:', error);
         this.pmtilesLoadedSuccessfully = false;

--- a/src/config/constants.js
+++ b/src/config/constants.js
@@ -189,14 +189,7 @@ export const INTERACTIVE_LAYERS_ZOOM_THRESHOLD = 15;
 export const COMMENTS_ZOOM_THRESHOLD = 13;
 export const MAP_AUTOCHANGE_AREA_ZOOM_THRESHOLD = 12;
 
-// DEFAULT_PMTILES_FILENAME
-//   br.pmtiles → PROD
-//   la_es_pt.pmtiles → PREVIEW
-//   br_es_pt.pmtiles
-//   la.pmtiles
-//   de.pmtiles
-//   europe.pmtiles (???)
-const DEFAULT_PMTILES_FILENAME = 'la_es_pt.pmtiles';
+const DEFAULT_PMTILES_FILENAME = 'spain.pmtiles';
 export const PMTILES_FILENAME = process.env.REACT_APP_PMTILES_FILENAME || DEFAULT_PMTILES_FILENAME;
 
 /*

--- a/yarn.lock
+++ b/yarn.lock
@@ -11413,7 +11413,7 @@ playwright@1.60.0:
   optionalDependencies:
     fsevents "2.3.2"
 
-pmtiles@^3.0.3:
+pmtiles@^3.0.3, pmtiles@^3.2.1:
   version "3.2.1"
   resolved "https://registry.npmjs.org/pmtiles/-/pmtiles-3.2.1.tgz"
   integrity sha512-3R4fBwwoli5mw7a6t1IGwOtfmcSAODq6Okz0zkXhS1zi9sz1ssjjIfslwPvcWw5TNhdjNBUg9fgfPLeqZlH6ng==


### PR DESCRIPTION

Plumbing to build regional PMTiles and push them to S3, without touching the app runtime. Local scripts + a manual GitHub Action so we can regenerate `br` / `la_es_pt` / etc without babysitting tippecanoe by hand.

### Pipeline
- `scripts/pmtiles-builds.json` defines the regional builds (Brazil, LatAm, Europe, POI variants, …).
- `scripts/sync-pmtiles-to-s3.js` runs generate for those builds, uploads to S3, and writes a before/after report (size, tiles, zoom/bounds, GeoJSON feature counts) under `.pmtiles-work/reports/`.
- Supports `--list-builds`, `--dry-run`, `--skip-geojson`, `--upload-only`, `--skip-upload`.
- Yarn shortcuts: `generate-pmtiles`, `pmtiles:list`, `pmtiles:sync`, `pmtiles:sync:dry-run`. Adds the `pmtiles` CLI package for inspecting archives.

### CI
- New workflow `.github/workflows/pmtiles.yml` (manual dispatch): pick a build (or `all`), optionally skip GeoJSON regen or upload-only.
- Installs tippecanoe on the runner, long timeout, concurrency group so europe builds don’t pile up.
- Uploads the change reports as artifacts.

### generate-pmtiles tweaks
- New area aliases: `latin america`, `es_pt`.
- By default excludes Baixa velocidade / Trilha / Proibido (same idea as the app’s non-PMTiles layers). Pass `--include-layers` if you want to override that.
- Exports helpers the sync script needs (`expandAreaAliases`, etc.).

### Docs / env
- `.env.example` for Map/routing keys, PMTiles URL/filename, and the AWS vars used by the sync script.
- README section on how the Overpass → GeoJSON → tippecanoe → S3 flow fits together.
- Ignore `.pmtiles-work/`.

### Smaller fixes
- Workflow: `persist-credentials: false` on checkout, and pass the build id via env instead of interpolating `${{ inputs.build }}` into the shell (injection-ish footgun).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added configurable PMTiles generation, regional builds, and synchronization with remote storage.
  * Added support for Latin America, Spain/Portugal, and expanded regional build options.
  * Added tracking and reporting for map data loading, including file and zoom metadata.
  * Updated the default map data file to Spain.

* **Documentation**
  * Added setup instructions for PMTiles generation, local workflows, CI, storage uploads, and reports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->